### PR TITLE
Add manual update support via uploaded release archive

### DIFF
--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -4,19 +4,40 @@ namespace App\Http\Controllers;
 
 use Codedge\Updater\UpdaterManager;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ZipArchive;
 class AppController extends Controller
 {
-    public function update(UpdaterManager $updater)
+    public function update(Request $request, UpdaterManager $updater)
     {
         if (config('app.hosted')) {
             return redirect()->back()->with('error', 'Not authorized');
         }
 
+        $request->validate([
+            'package' => ['nullable', 'file', 'mimes:zip'],
+        ]);
+
+        if ($request->hasFile('package')) {
+            try {
+                $this->updateFromUploadedArchive($request->file('package'));
+            } catch (\Throwable $e) {
+                return redirect()->back()->with('error', $e->getMessage());
+            }
+
+            return redirect()->back()->with('message', __('messages.app_updated'));
+        }
+
         try {
             if ($updater->source()->isNewVersionAvailable()) {
                 $versionAvailable = $updater->source()->getVersionAvailable();
-                
+
                 $release = $updater->source()->fetch($versionAvailable);
                 
                 $updater->source()->update($release);   
@@ -71,5 +92,117 @@ class AppController extends Controller
         \Artisan::call('app:translate');
 
         return response()->json(['success' => true]);
+    }
+
+    private function updateFromUploadedArchive(UploadedFile $archive): void
+    {
+        Storage::disk('local')->makeDirectory('manual-updates');
+
+        $filename = 'manual-' . Str::uuid() . '.zip';
+        $relativeZipPath = $archive->storeAs('manual-updates', $filename);
+        $zipPath = storage_path('app/' . $relativeZipPath);
+        $extractPath = storage_path('app/manual-updates/' . pathinfo($filename, PATHINFO_FILENAME));
+
+        File::ensureDirectoryExists($extractPath);
+
+        try {
+            $zip = new ZipArchive();
+
+            if ($zip->open($zipPath) !== true) {
+                throw new \RuntimeException('Unable to open the uploaded update archive.');
+            }
+
+            if (! $zip->extractTo($extractPath)) {
+                $zip->close();
+                throw new \RuntimeException('Unable to extract the uploaded update archive.');
+            }
+
+            $zip->close();
+
+            $releaseRoot = $this->resolveReleaseRoot($extractPath);
+
+            if (! $releaseRoot || ! File::isDirectory($releaseRoot)) {
+                throw new \RuntimeException('The uploaded archive did not contain a valid release.');
+            }
+
+            $this->copyReleaseContents($releaseRoot, base_path());
+
+            Artisan::call('migrate', ['--force' => true]);
+        } finally {
+            if (file_exists($zipPath)) {
+                unlink($zipPath);
+            }
+
+            if (File::isDirectory($extractPath)) {
+                File::deleteDirectory($extractPath);
+            }
+        }
+    }
+
+    private function resolveReleaseRoot(string $extractPath): string
+    {
+        $directories = File::directories($extractPath);
+        $files = File::files($extractPath);
+
+        if (empty($files) && count($directories) === 1) {
+            return $directories[0];
+        }
+
+        return $extractPath;
+    }
+
+    private function copyReleaseContents(string $source, string $destination): void
+    {
+        $excludeFolders = collect(config('self-update.exclude_folders', []))
+            ->merge(['vendor'])
+            ->map(fn ($folder) => trim($folder, '/'))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            $relativePath = ltrim(Str::replaceFirst($source, '', $item->getPathname()), DIRECTORY_SEPARATOR);
+            $relativePath = str_replace('\\', '/', $relativePath);
+
+            if ($relativePath === '' || $relativePath === '.env') {
+                continue;
+            }
+
+            if ($this->shouldSkipPath($relativePath, $excludeFolders)) {
+                continue;
+            }
+
+            $targetPath = $destination . '/' . $relativePath;
+
+            if ($item->isDir()) {
+                File::ensureDirectoryExists($targetPath);
+                continue;
+            }
+
+            File::ensureDirectoryExists(dirname($targetPath));
+
+            if (File::exists($targetPath)) {
+                File::delete($targetPath);
+            }
+
+            File::copy($item->getPathname(), $targetPath);
+        }
+    }
+
+    private function shouldSkipPath(string $relativePath, array $excludeFolders): bool
+    {
+        foreach ($excludeFolders as $folder) {
+            if ($relativePath === $folder || Str::startsWith($relativePath, $folder . '/')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/resources/views/profile/partials/update-app-form.blade.php
+++ b/resources/views/profile/partials/update-app-form.blade.php
@@ -29,18 +29,28 @@
     <form method="POST" action="{{ route('app.update') }}" enctype="multipart/form-data" class="mt-6">
         @csrf
 
-    @if ($version_installed != $version_available)
-        <x-primary-button>{{ __('messages.update') }}</x-primary-button>
-
-        <div class="text-gray-600 dark:text-gray-400 pt-6"> 
-            {!! __('messages.app_update_tip', ['link' => '<a href="https://github.com/eventschedule/eventschedule/releases/download/' . $version_available . '/eventschedule.zip" class="hover:underline">eventschedule.zip</a>']) !!}
+        <div class="mt-4">
+            <x-input-label for="package" :value="__('Upload release ZIP (optional)')" />
+            <input id="package" name="package" type="file" accept=".zip"
+                class="mt-1 block w-full text-gray-900 dark:text-gray-100" />
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                {{ __('Use this when the server cannot reach GitHub; the archive will be applied directly.') }}
+            </p>
+            <x-input-error class="mt-2" :messages="$errors->get('package')" />
         </div>
-    @else
-        <div class="text-gray-600 dark:text-gray-400 pb-4"> 
-            <b>{{ __('messages.up_to_date') }}</b>
-        </div>
 
-    @endif
+        <x-primary-button class="mt-6">{{ __('messages.update') }}</x-primary-button>
+
+        @if ($version_installed != $version_available)
+            <div class="text-gray-600 dark:text-gray-400 pt-6">
+                {!! __('messages.app_update_tip', ['link' => '<a href="https://github.com/eventschedule/eventschedule/releases/download/' . $version_available . '/eventschedule.zip" class="hover:underline">eventschedule.zip</a>']) !!}
+            </div>
+        @else
+            <div class="text-gray-600 dark:text-gray-400 pb-4">
+                <b>{{ __('messages.up_to_date') }}</b>
+            </div>
+
+        @endif
 
     </form>
 


### PR DESCRIPTION
## Summary
- allow the updater endpoint to accept an uploaded release ZIP and apply it locally when provided
- extract the archive, skip excluded folders, and clean up temporary files after running migrations
- expose a ZIP upload control on the profile update card so admins can trigger manual updates from the UI

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing because Composer dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8afd1d2c832ea98cd66b9022a860