### PR TITLE
Improve updater permission guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ Copy [eventschedule.zip](https://github.com/eventschedule/eventschedule/releases
 
 ### 3. Set File Permissions
 
-Ensure correct permissions for storage and cache directories:
+The self-updater copies new releases directly into your installation. Make sure the
+project is owned by the web server user (replace `www-data` with the user that runs PHP on your server):
 
 ```bash
 cd /path/to/eventschedule
-chmod -R 755 storage
-sudo chown -R www-data:www-data storage bootstrap public
+sudo chown -R www-data:www-data .
 ```
+
+If you prefer to scope ownership more narrowly, ensure these directories remain writable by the web user:
+`app`, `bootstrap`, `config`, `database`, `public`, `resources`, `routes`, and `storage`.
 
 ---
 

--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -231,12 +231,19 @@ class AppController extends Controller
             $relativeDirectory = '.';
         }
 
+        $exampleCommand = sprintf(
+            'sudo chown -R www-data:www-data %s',
+            escapeshellarg(base_path())
+        );
+
         throw new RuntimeException(
             sprintf(
                 'Unable to copy the update file "%s" because the "%s" directory is not writable. '
-                . 'Please adjust the directory permissions and try again.',
+                . 'Please adjust the directory permissions and try again. '
+                . 'Ensure the application files are owned by the web server user (for example: %s).',
                 $relativePath,
-                $relativeDirectory
+                $relativeDirectory,
+                $exampleCommand
             )
         );
     }


### PR DESCRIPTION
## Summary
- clarify the installation guide so the web server user owns the application directory required by the self-updater
- include a concrete ownership command in the updater's permission error to help resolve manual update failures

## Testing
- php -l app/Http/Controllers/AppController.php

------
https://chatgpt.com/codex/tasks/task_e_68cd8081c278832e8748a09ef18d1504