### PR TITLE
Handle missing events.view route gracefully

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -32,6 +32,9 @@
                 'name' => $role->name,
             ];
         })->values();
+
+        $eventViewRouteName = 'events.view';
+        $eventViewRouteExists = \Illuminate\Support\Facades\Route::has($eventViewRouteName);
     @endphp
 
     <div class="py-5">
@@ -182,8 +185,24 @@
                                             </td>
                                             <td class="px-6 py-4 align-top">
                                                 <div class="flex items-center justify-end space-x-3">
-                                                    @if (\Illuminate\Support\Facades\Route::has('events.view'))
-                                                        <a href="{{ route('events.view', ['hash' => $hashedId]) }}" class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{{ __('messages.view') }}</a>
+                                                    @php
+                                                        $eventViewUrl = null;
+
+                                                        if ($eventViewRouteExists ?? false) {
+                                                            $eventViewUrl = rescue(
+                                                                fn () => route($eventViewRouteName, ['hash' => $hashedId]),
+                                                                null,
+                                                                false
+                                                            );
+
+                                                            if (! $eventViewUrl) {
+                                                                $eventViewRouteExists = false;
+                                                            }
+                                                        }
+                                                    @endphp
+
+                                                    @if ($eventViewUrl)
+                                                        <a href="{{ $eventViewUrl }}" class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{{ __('messages.view') }}</a>
                                                     @endif
                                                     @if ($canEdit)
                                                         <a href="{{ route('event.edit_admin', ['hash' => $hashedId]) }}" class="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-100">{{ __('messages.edit') }}</a>


### PR DESCRIPTION
## Summary
- track availability of the `events.view` route in the home dashboard view
- guard creation of the event view link so missing routes no longer throw exceptions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd8e0fec64832e9e700ff51df39a15