### PR TITLE
Handle mailer failure inspection when failures method missing

### DIFF
--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -125,7 +125,9 @@ class SettingsTest extends TestCase
             })
             ->andReturnNull();
 
-        Mail::shouldReceive('failures')->once()->andReturn([]);
+        $mailer = $this->makeMailerStub([]);
+
+        Mail::shouldReceive('mailer')->once()->andReturn($mailer);
 
         $payload = [
             'mail_mailer' => 'smtp',
@@ -197,7 +199,9 @@ class SettingsTest extends TestCase
             })
             ->andReturnNull();
 
-        Mail::shouldReceive('failures')->once()->andReturn(['failed@example.com']);
+        $mailer = $this->makeMailerStub(['failed@example.com']);
+
+        Mail::shouldReceive('mailer')->once()->andReturn($mailer);
 
         $payload = [
             'mail_mailer' => 'smtp',
@@ -259,7 +263,7 @@ class SettingsTest extends TestCase
             ->withAnyArgs()
             ->andThrow(new RuntimeException('SMTP connection refused'));
 
-        Mail::shouldReceive('failures')->never();
+        Mail::shouldReceive('mailer')->never();
 
         $payload = [
             'mail_mailer' => 'smtp',
@@ -329,7 +333,7 @@ class SettingsTest extends TestCase
         ]);
 
         Mail::shouldReceive('raw')->never();
-        Mail::shouldReceive('failures')->never();
+        Mail::shouldReceive('mailer')->never();
 
         $payload = [
             'mail_mailer' => 'smtp',
@@ -391,5 +395,20 @@ class SettingsTest extends TestCase
         ]);
 
         $this->assertSame('https://example.org', config('app.url'));
+    }
+
+    protected function makeMailerStub(array $failures): object
+    {
+        return new class($failures)
+        {
+            public function __construct(private array $failures)
+            {
+            }
+
+            public function failures(): array
+            {
+                return $this->failures;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable mailer failure inspection helper that tolerates drivers without a `failures()` method
- switch test-email endpoints to rely on the helper so missing methods no longer trigger fatal errors
- update feature tests to stub `Mail::mailer()` and cover the new inspection helper

## Testing
- `composer install` *(fails: GitHub API returned 403 and requested authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68d15d51dde0832eb28f9f4ff6683e65