### PR TITLE
Start forked release track at v1.0.32-dfiore1230

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,6 @@ jobs:
           draft: false
           prerelease: false
           title: "Latest Release"
-          automatic_release_tag: "v1.0.32"
+          automatic_release_tag: "v1.0.32-dfiore1230"
           files: |
             eventschedule.zip

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Listeners\LogSentMessage;
 use App\Models\Setting;
+use App\Support\UpdateConfigManager;
 use App\Support\WalletConfigManager;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Notifications\Events\NotificationSent;
@@ -65,6 +66,8 @@ class AppServiceProvider extends ServiceProvider
 
         if (Schema::hasTable('settings')) {
             $generalSettings = Setting::forGroup('general');
+
+            UpdateConfigManager::apply($generalSettings['update_repository_url'] ?? null);
 
             if (!empty($generalSettings['public_url'])) {
                 config(['app.url' => $generalSettings['public_url']]);

--- a/app/Support/UpdateConfigManager.php
+++ b/app/Support/UpdateConfigManager.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Arr;
+
+class UpdateConfigManager
+{
+    public static function apply(?string $repositoryUrl): void
+    {
+        $defaults = config('self-update.github_defaults');
+
+        $sanitizedUrl = static::sanitizeUrl($repositoryUrl);
+        $urlToUse = $sanitizedUrl ?? ($defaults['url'] ?? null);
+
+        if ($urlToUse) {
+            config(['self-update.repository_types.github.repository_url' => $urlToUse]);
+        }
+
+        $details = $urlToUse ? static::deriveRepositoryDetails($urlToUse) : null;
+
+        if ($details !== null) {
+            config([
+                'self-update.repository_types.github.repository_vendor' => $details['vendor'],
+                'self-update.repository_types.github.repository_name' => $details['name'],
+            ]);
+        } elseif (! empty($defaults)) {
+            config([
+                'self-update.repository_types.github.repository_vendor' => $defaults['vendor'] ?? null,
+                'self-update.repository_types.github.repository_name' => $defaults['name'] ?? null,
+            ]);
+        }
+    }
+
+    public static function makeReleaseDownloadUrl(string $version): ?string
+    {
+        $repositoryUrl = config('self-update.repository_types.github.repository_url');
+        $packageName = config('self-update.repository_types.github.package_file_name', 'eventschedule.zip');
+
+        if (empty($repositoryUrl)) {
+            return null;
+        }
+
+        $details = static::deriveRepositoryDetails($repositoryUrl);
+
+        if ($details === null) {
+            return rtrim($repositoryUrl, '/') . '/releases';
+        }
+
+        $base = rtrim(sprintf('https://github.com/%s/%s', $details['vendor'], $details['name']), '/');
+
+        return sprintf('%s/releases/download/%s/%s', $base, $version, $packageName);
+    }
+
+    protected static function sanitizeUrl(?string $url): ?string
+    {
+        if (! is_string($url)) {
+            return null;
+        }
+
+        $trimmed = trim($url);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return rtrim($trimmed, '/');
+    }
+
+    protected static function deriveRepositoryDetails(string $repositoryUrl): ?array
+    {
+        $parsed = parse_url($repositoryUrl);
+
+        if ($parsed === false || empty($parsed['path'])) {
+            return null;
+        }
+
+        $segments = array_values(array_filter(explode('/', $parsed['path'])));
+
+        if (count($segments) < 2) {
+            return null;
+        }
+
+        $vendor = Arr::get($segments, count($segments) - 2);
+        $name = Arr::get($segments, count($segments) - 1);
+
+        if (! is_string($vendor) || $vendor === '' || ! is_string($name) || $name === '') {
+            return null;
+        }
+
+        $name = preg_replace('/\.git$/', '', $name) ?: $name;
+
+        return [
+            'vendor' => $vendor,
+            'name' => $name,
+        ];
+    }
+}

--- a/config/self-update.php
+++ b/config/self-update.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+$defaultGithubVendor = env('SELF_UPDATER_REPO_VENDOR', 'eventschedule');
+$defaultGithubName = env('SELF_UPDATER_REPO_NAME', 'eventschedule');
+$defaultGithubUrl = env('SELF_UPDATER_REPO_URL', 'https://github.com/eventschedule/eventschedule');
+
 return [
 
     /*
@@ -24,7 +28,13 @@ return [
     |
     */
 
-    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', 'v1.0.32'),
+    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', 'v1.0.32-dfiore1230'),
+
+    'github_defaults' => [
+        'vendor' => $defaultGithubVendor,
+        'name' => $defaultGithubName,
+        'url' => $defaultGithubUrl,
+    ],
 
     /*
     |--------------------------------------------------------------------------
@@ -42,9 +52,9 @@ return [
     'repository_types' => [
         'github' => [
             'type'                 => 'github',
-            'repository_vendor'    => env('SELF_UPDATER_REPO_VENDOR', 'eventschedule'),
-            'repository_name'      => env('SELF_UPDATER_REPO_NAME', 'eventschedule'),
-            'repository_url'       => 'https://github.com/eventschedule/eventschedule',
+            'repository_vendor'    => $defaultGithubVendor,
+            'repository_name'      => $defaultGithubName,
+            'repository_url'       => $defaultGithubUrl,
             'download_path'        => env('SELF_UPDATER_DOWNLOAD_PATH', '/tmp'),
             'private_access_token' => env('SELF_UPDATER_GITHUB_PRIVATE_ACCESS_TOKEN', ''),
             'use_branch'           => env('SELF_UPDATER_USE_BRANCH', ''),

--- a/resources/lang/ar/messages.php
+++ b/resources/lang/ar/messages.php
@@ -135,6 +135,8 @@ return [
     'back_to_email_templates' => 'العودة إلى القوالب',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -136,6 +136,8 @@ return [
     'back_to_email_templates' => 'Zurück zu den Vorlagen',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -145,6 +145,8 @@ return [
     'back_to_email_templates' => 'Back to templates',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -135,6 +135,8 @@ return [
     'back_to_email_templates' => 'Volver a las plantillas',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -135,6 +135,8 @@ return [
     'back_to_email_templates' => 'Retour aux modèles',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/he/messages.php
+++ b/resources/lang/he/messages.php
@@ -136,6 +136,8 @@ return [
     'back_to_email_templates' => 'חזרה לתבניות',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/it/messages.php
+++ b/resources/lang/it/messages.php
@@ -136,6 +136,8 @@ return [
     'back_to_email_templates' => 'Torna ai modelli',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -135,6 +135,8 @@ return [
     'back_to_email_templates' => 'Terug naar sjablonen',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -136,6 +136,8 @@ return [
     'back_to_email_templates' => 'Voltar aos modelos',
     'public_url' => 'Public URL',
     'public_url_help' => 'This URL is used when generating public links for schedules, events, and emails.',
+    'update_repository_url' => 'Update repository URL',
+    'update_repository_url_help' => 'Set the repository URL that should be checked for new releases. Leave blank to use the default.',
     'general_settings_saved' => 'General settings saved successfully.',
     'email_template_subject' => 'Subject',
     'email_template_subject_curated' => 'Subject (Curated schedules)',

--- a/resources/views/layouts/app-admin.blade.php
+++ b/resources/views/layouts/app-admin.blade.php
@@ -176,7 +176,7 @@
                     <!-- Per the AAL license, please do not remove the link to Event Schedule -->
                     {!! str_replace(':link', '<a href="https://www.eventschedule.com" class="hover:underline" target="_blank">eventschedule.com</a>', __('messages.powered_by_eventschedule')) !!} 
                     • 
-                    <a href="https://github.com/eventschedule/eventschedule" target="_blank" class="hover:underline">{{ config('self-update.version_installed') }}</a>
+                    <a href="{{ config('self-update.repository_types.github.repository_url') }}" target="_blank" class="hover:underline">{{ config('self-update.version_installed') }}</a>
                 @endif
             </div>
 

--- a/resources/views/profile/partials/update-app-form.blade.php
+++ b/resources/views/profile/partials/update-app-form.blade.php
@@ -42,9 +42,26 @@
         <x-primary-button class="mt-6">{{ __('messages.update') }}</x-primary-button>
 
         @if ($version_installed != $version_available)
-            <div class="text-gray-600 dark:text-gray-400 pt-6">
-                {!! __('messages.app_update_tip', ['link' => '<a href="https://github.com/eventschedule/eventschedule/releases/download/' . $version_available . '/eventschedule.zip" class="hover:underline">eventschedule.zip</a>']) !!}
-            </div>
+            @php
+                $downloadUrl = $version_available ? \App\Support\UpdateConfigManager::makeReleaseDownloadUrl($version_available) : null;
+                $downloadLabel = config('self-update.repository_types.github.package_file_name', 'eventschedule.zip');
+
+                if ($downloadUrl) {
+                    $path = parse_url($downloadUrl, PHP_URL_PATH);
+                    if (is_string($path)) {
+                        $basename = basename($path);
+
+                        if (! empty($basename)) {
+                            $downloadLabel = $basename;
+                        }
+                    }
+                }
+            @endphp
+            @if ($downloadUrl)
+                <div class="text-gray-600 dark:text-gray-400 pt-6">
+                    {!! __('messages.app_update_tip', ['link' => '<a href="' . e($downloadUrl) . '" class="hover:underline">' . e($downloadLabel) . '</a>']) !!}
+                </div>
+            @endif
         @else
             <div class="text-gray-600 dark:text-gray-400 pb-4">
                 <b>{{ __('messages.up_to_date') }}</b>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -37,6 +37,18 @@
                                 <x-input-error class="mt-2" :messages="$errors->get('public_url')" />
                             </div>
 
+                            <div>
+                                <x-input-label for="update_repository_url" :value="__('messages.update_repository_url')" />
+                                <x-text-input id="update_repository_url" name="update_repository_url" type="url"
+                                    class="mt-1 block w-full"
+                                    :value="old('update_repository_url', $generalSettings['update_repository_url'])"
+                                    autocomplete="off" />
+                                <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                    {{ __('messages.update_repository_url_help') }}
+                                </p>
+                                <x-input-error class="mt-2" :messages="$errors->get('update_repository_url')" />
+                            </div>
+
                             <div class="flex items-center gap-4">
                                 <x-primary-button>{{ __('messages.save') }}</x-primary-button>
 

--- a/storage/bump_version.sh
+++ b/storage/bump_version.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
 
-current_version=$(grep "automatic_release_tag" .github/workflows/build.yml | grep -o "v1.0.[0-9]*" | cut -d "." -f3)
-new_version=$((current_version+1))
-date_today=$(date +%F)
+VERSION_PREFIX="v1.0."
+VERSION_PREFIX_REGEX="v1\\.0\."
+VERSION_SUFFIX="-dfiore1230"
 
-echo "Bump version... $current_version => $new_version"
+current_index=$(grep "automatic_release_tag" .github/workflows/build.yml | grep -o "${VERSION_PREFIX_REGEX}[0-9]*" | cut -d "." -f3)
+new_index=$((current_index+1))
 
-sed -i -e "s/automatic_release_tag: \"v1.0.$current_version\"/automatic_release_tag: \"v1.0.$new_version\"/g" .github/workflows/build.yml
-sed -i -e "s/'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', 'v1.0.$current_version')/'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', 'v1.0.$new_version')/g" config/self-update.php
+current_version="${VERSION_PREFIX}${current_index}${VERSION_SUFFIX}"
+new_version="${VERSION_PREFIX}${new_index}${VERSION_SUFFIX}"
 
-rm .github/workflows/build.yml-e
-rm config/self-update.php-e
+echo "Bump version... ${current_version} => ${new_version}"
+
+sed -i -e "s/automatic_release_tag: \"${current_version}\"/automatic_release_tag: \"${new_version}\"/g" .github/workflows/build.yml
+sed -i -e "s/'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '${current_version}')/'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '${new_version}')/g" config/self-update.php
+
+rm -f .github/workflows/build.yml-e
+rm -f config/self-update.php-e


### PR DESCRIPTION
## Summary
- bump the bundled build version to v1.0.32-dfiore1230, update the automatic release tag, and ensure the bump script tracks the new suffix
- introduce an UpdateConfigManager that applies repository overrides during bootstrap and general settings updates
- allow admins to configure the update repository URL in the general settings UI, update the manual download hint/footer link, and localize the new fields

## Testing
- bash -n storage/bump_version.sh

------
https://chatgpt.com/codex/tasks/task_e_68d16ee718ec832e8c4f2611fc68521d