### PR TITLE
Fix mailer purge call after test email

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -432,7 +432,7 @@ class SettingsController extends Controller
             ], 500);
         } finally {
             $this->applyMailConfig($originalSettings);
-            $this->purgeResolvedMailer($originalSettings['mailer'] ?? null);
+            MailConfigManager::purgeResolvedMailer($originalSettings['mailer'] ?? null);
         }
     }
 


### PR DESCRIPTION
## Summary
- restore mail configuration cleanup in the test mail endpoint by calling MailConfigManager::purgeResolvedMailer instead of a non-existent controller helper

## Testing
- `./vendor/bin/phpunit --filter SettingsTest` *(fails: vendor binaries missing prior to dependency install)*
- `composer install` *(fails: GitHub API returned 403 requiring authentication, blocking dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68d29963e734832e9f156015d4ebff36