### PR TITLE
Ensure ticket emails use configured mail transport

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -788,44 +788,7 @@ class SettingsController extends Controller
 
     protected function applyMailConfig(array $settings): void
     {
-        if (array_key_exists('smtp_url', $settings)) {
-            config(['mail.mailers.smtp.url' => $settings['smtp_url']]);
-        } elseif (($settings['mailer'] ?? config('mail.default')) === 'smtp' && config('mail.mailers.smtp.url') !== null) {
-            config(['mail.mailers.smtp.url' => null]);
-        }
-
-        config(['mail.default' => $settings['mailer']]);
-
-        if ($settings['host'] !== null) {
-            config(['mail.mailers.smtp.host' => $settings['host']]);
-        }
-
-        if ($settings['port'] !== null) {
-            config(['mail.mailers.smtp.port' => (int) $settings['port']]);
-        }
-
-        if ($settings['username'] !== null) {
-            config(['mail.mailers.smtp.username' => $settings['username']]);
-        }
-
-        if ($settings['password'] !== null) {
-            config(['mail.mailers.smtp.password' => $settings['password']]);
-        }
-
-        if ($settings['encryption'] !== null) {
-            config(['mail.mailers.smtp.encryption' => $settings['encryption'] ?: null]);
-        }
-
-        config([
-            'mail.from.address' => $settings['from_address'],
-            'mail.from.name' => $settings['from_name'],
-        ]);
-
-        if (array_key_exists('disable_delivery', $settings) && $settings['disable_delivery'] !== null) {
-            config(['mail.disable_delivery' => $this->toBoolean($settings['disable_delivery'])]);
-        }
-
-        MailConfigManager::purgeResolvedMailer($settings['mailer'] ?? null);
+        MailConfigManager::apply($settings);
     }
 
     protected function nullableTrim(?string $value): ?string

--- a/app/Notifications/TicketCancelledNotification.php
+++ b/app/Notifications/TicketCancelledNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Role;
 use App\Models\Sale;
+use App\Support\MailConfigManager;
 use App\Support\MailTemplateManager;
 use App\Utils\NotificationUtils;
 use App\Utils\UrlUtils;
@@ -28,6 +29,12 @@ class TicketCancelledNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         $templates = app(MailTemplateManager::class);
 
         return $templates->enabled($this->templateKey()) ? ['mail'] : [];

--- a/app/Notifications/TicketPaidNotification.php
+++ b/app/Notifications/TicketPaidNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Role;
 use App\Models\Sale;
+use App\Support\MailConfigManager;
 use App\Support\MailTemplateManager;
 use App\Utils\NotificationUtils;
 use App\Utils\UrlUtils;
@@ -30,6 +31,12 @@ class TicketPaidNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         $templates = app(MailTemplateManager::class);
 
         return $templates->enabled($this->templateKey()) ? ['mail'] : [];

--- a/app/Notifications/TicketSaleNotification.php
+++ b/app/Notifications/TicketSaleNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Role;
 use App\Models\Sale;
+use App\Support\MailConfigManager;
 use App\Support\MailTemplateManager;
 use App\Utils\NotificationUtils;
 use App\Utils\UrlUtils;
@@ -28,6 +29,12 @@ class TicketSaleNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         $templates = app(MailTemplateManager::class);
 
         return $templates->enabled($this->templateKey()) ? ['mail'] : [];

--- a/app/Notifications/TicketTimeoutNotification.php
+++ b/app/Notifications/TicketTimeoutNotification.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Role;
 use App\Models\Sale;
+use App\Support\MailConfigManager;
 use App\Support\MailTemplateManager;
 use App\Utils\NotificationUtils;
 use App\Utils\UrlUtils;
@@ -28,6 +29,12 @@ class TicketTimeoutNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         $templates = app(MailTemplateManager::class);
 
         return $templates->enabled($this->templateKey()) ? ['mail'] : [];

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -78,59 +78,7 @@ class AppServiceProvider extends ServiceProvider
             $mailSettings = Setting::forGroup('mail');
 
             if (!empty($mailSettings)) {
-                if (config('mail.mailers.smtp.url') !== null) {
-                    config(['mail.mailers.smtp.url' => null]);
-                }
-
-                $mailer = $mailSettings['mailer'] ?? null;
-
-                if (!empty($mailSettings['mailer'])) {
-                    config(['mail.default' => $mailSettings['mailer']]);
-                }
-
-                if (array_key_exists('host', $mailSettings) && $mailSettings['host'] !== null) {
-                    config(['mail.mailers.smtp.host' => $mailSettings['host']]);
-                }
-
-                if (array_key_exists('port', $mailSettings) && $mailSettings['port'] !== null) {
-                    config(['mail.mailers.smtp.port' => (int) $mailSettings['port']]);
-                }
-
-                if (array_key_exists('username', $mailSettings) && $mailSettings['username'] !== null) {
-                    config(['mail.mailers.smtp.username' => $mailSettings['username']]);
-                }
-
-                if (array_key_exists('password', $mailSettings) && $mailSettings['password'] !== null) {
-                    config(['mail.mailers.smtp.password' => $mailSettings['password']]);
-                }
-
-                if (array_key_exists('encryption', $mailSettings)) {
-                    config(['mail.mailers.smtp.encryption' => $mailSettings['encryption'] ?: null]);
-                }
-
-                if (!empty($mailSettings['from_address'])) {
-                    config(['mail.from.address' => $mailSettings['from_address']]);
-                }
-
-                if (!empty($mailSettings['from_name'])) {
-                    config(['mail.from.name' => $mailSettings['from_name']]);
-                }
-
-                if (array_key_exists('disable_delivery', $mailSettings) && $mailSettings['disable_delivery'] !== null) {
-                    $disableDelivery = $mailSettings['disable_delivery'];
-
-                    if (! is_bool($disableDelivery)) {
-                        $disableDelivery = in_array(
-                            strtolower((string) $disableDelivery),
-                            ['1', 'true', 'yes', 'on'],
-                            true
-                        );
-                    }
-
-                    config(['mail.disable_delivery' => (bool) $disableDelivery]);
-                }
-
-                MailConfigManager::purgeResolvedMailer($mailer);
+                MailConfigManager::apply($mailSettings);
             }
 
             $appleWalletSettings = Setting::forGroup('wallet.apple');

--- a/app/Repos/EventRepo.php
+++ b/app/Repos/EventRepo.php
@@ -17,6 +17,7 @@ use App\Mail\ClaimVenue;
 use App\Notifications\EventAddedNotification;
 use App\Utils\NotificationUtils;
 use App\Models\Ticket;
+use App\Support\MailConfigManager;
 use App\Support\MailTemplateManager;
 
 
@@ -299,6 +300,8 @@ class EventRepo
             $event->flyer_image_url = $filename;
             $event->save();
         }
+
+        MailConfigManager::applyFromDatabase();
 
         if (! config('mail.disable_delivery')) {
             $templates = app(MailTemplateManager::class);

--- a/app/Support/MailConfigManager.php
+++ b/app/Support/MailConfigManager.php
@@ -2,8 +2,80 @@
 
 namespace App\Support;
 
+use App\Models\Setting;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
+
 class MailConfigManager
 {
+    /**
+     * Cache the hash of the last applied settings so we only rebuild the mailer
+     * transport when something actually changes.
+     */
+    protected static ?string $appliedHash = null;
+
+    public static function applyFromDatabase(): void
+    {
+        if (! Schema::hasTable('settings')) {
+            return;
+        }
+
+        $mailSettings = Setting::forGroup('mail');
+
+        if (empty($mailSettings)) {
+            return;
+        }
+
+        static::apply($mailSettings);
+    }
+
+    public static function apply(array $settings): void
+    {
+        $normalized = static::normalizeSettings($settings);
+
+        $hash = md5(json_encode($normalized));
+
+        if ($hash === static::$appliedHash) {
+            return;
+        }
+
+        static::$appliedHash = $hash;
+
+        $mailer = $normalized['mailer'] ?? null;
+
+        if (array_key_exists('mailer', $normalized) && $normalized['mailer'] !== null) {
+            config(['mail.default' => $normalized['mailer']]);
+        }
+
+        if (array_key_exists('smtp_url', $normalized)) {
+            config(['mail.mailers.smtp.url' => $normalized['smtp_url']]);
+        } elseif (($mailer ?? config('mail.default')) === 'smtp' && config('mail.mailers.smtp.url') !== null) {
+            config(['mail.mailers.smtp.url' => null]);
+        }
+
+        foreach (['host', 'username', 'password', 'encryption'] as $key) {
+            if (array_key_exists($key, $normalized) && $normalized[$key] !== null) {
+                config(["mail.mailers.smtp.{$key}" => $normalized[$key]]);
+            }
+        }
+
+        if (array_key_exists('port', $normalized) && $normalized['port'] !== null) {
+            config(['mail.mailers.smtp.port' => $normalized['port']]);
+        }
+
+        foreach (['from_address' => 'address', 'from_name' => 'name'] as $source => $target) {
+            if (array_key_exists($source, $normalized) && $normalized[$source] !== null) {
+                config(["mail.from.{$target}" => $normalized[$source]]);
+            }
+        }
+
+        if (array_key_exists('disable_delivery', $normalized) && $normalized['disable_delivery'] !== null) {
+            config(['mail.disable_delivery' => $normalized['disable_delivery']]);
+        }
+
+        static::purgeResolvedMailer($mailer);
+    }
+
     public static function purgeResolvedMailer(?string $mailer = null): void
     {
         if (app()->bound('mail.manager')) {
@@ -15,5 +87,85 @@ class MailConfigManager
         if (method_exists(app(), 'forgetResolvedInstance')) {
             app()->forgetResolvedInstance('mailer');
         }
+    }
+
+    protected static function normalizeSettings(array $settings): array
+    {
+        $normalized = [];
+
+        if (Arr::exists($settings, 'mailer')) {
+            $normalized['mailer'] = $settings['mailer'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'smtp_url')) {
+            $normalized['smtp_url'] = $settings['smtp_url'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'host')) {
+            $normalized['host'] = $settings['host'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'port')) {
+            $normalized['port'] = $settings['port'] !== null && $settings['port'] !== ''
+                ? (int) $settings['port']
+                : null;
+        }
+
+        if (Arr::exists($settings, 'username')) {
+            $normalized['username'] = $settings['username'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'password')) {
+            $normalized['password'] = $settings['password'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'encryption')) {
+            $normalized['encryption'] = $settings['encryption'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'from_address')) {
+            $normalized['from_address'] = $settings['from_address'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'from_name')) {
+            $normalized['from_name'] = $settings['from_name'] ?: null;
+        }
+
+        if (Arr::exists($settings, 'disable_delivery')) {
+            $normalized['disable_delivery'] = static::toBoolean($settings['disable_delivery']);
+        }
+
+        return $normalized;
+    }
+
+    protected static function toBoolean(mixed $value): ?bool
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (bool) $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (in_array($normalized, ['1', 'true', 'yes', 'on'], true)) {
+            return true;
+        }
+
+        if (in_array($normalized, ['0', 'false', 'no', 'off'], true)) {
+            return false;
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- centralize applying stored mail transport settings in `MailConfigManager` and reuse it across the app
- refresh configured mail settings before ticket notifications and organizer claim emails are sent so SMTP credentials are honored
- update the settings controller and app bootstrap to use the shared mail configuration logic

## Testing
- `php artisan test --testsuite=Unit` *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a3d72f7c832e8f0d4ee4879bbd8c