### PR TITLE
Display ticket availability on events page

### DIFF
--- a/resources/lang/ar/messages.php
+++ b/resources/lang/ar/messages.php
@@ -400,6 +400,7 @@ return [
     'customer' => 'العميل',
     'transaction_reference' => 'مرجع المعاملة',
     'total' => 'الإجمالي',
+    'remaining' => 'المتبقي',
     'number_of_attendees' => 'عدد الحضور',
     'terms_and_conditions' => 'الشروط والأحكام',
     'event_support_contact' => 'اتصال دعم الحدث',

--- a/resources/lang/de/messages.php
+++ b/resources/lang/de/messages.php
@@ -402,6 +402,7 @@ return [
     'customer' => 'Kunde',
     'transaction_reference' => 'Transaktionsreferenz',
     'total' => 'Gesamt',
+    'remaining' => 'Verbleibend',
     'number_of_attendees' => 'Anzahl der Teilnehmer',
     'terms_and_conditions' => 'Allgemeine Geschäftsbedingungen',
     'event_support_contact' => 'Event-Support-Kontakt',

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -511,6 +511,7 @@ return [
     'customer' => 'Customer',
     'transaction_reference' => 'Transaction Reference',
     'total' => 'Total',
+    'remaining' => 'Remaining',
     'number_of_attendees' => 'Number of Attendees',
     'terms_and_conditions' => 'Terms & Conditions',
     'terms_public_note' => 'This page is publicly accessible so guests and ticket holders can review the Terms & Conditions at any time.',

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -406,6 +406,7 @@ return [
     'customer' => 'Cliente',
     'transaction_reference' => 'Referencia de transacción',
     'total' => 'Total',
+    'remaining' => 'Restantes',
     'number_of_attendees' => 'Número de asistentes',
     'terms_and_conditions' => 'Términos y condiciones',
     'event_support_contact' => 'Contacto de soporte del evento',

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -405,6 +405,7 @@ return [
     'customer' => 'Client',
     'transaction_reference' => 'Référence de transaction',
     'total' => 'Total',
+    'remaining' => 'Restants',
     'number_of_attendees' => 'Nombre de participants',
     'terms_and_conditions' => 'Termes et conditions',
     'event_support_contact' => 'Contact de support événementiel',

--- a/resources/lang/he/messages.php
+++ b/resources/lang/he/messages.php
@@ -586,6 +586,7 @@ return [
     'customer' => 'לקוח',
     'transaction_reference' => 'התייחסות עסקה',
     'total' => 'סה"כ',
+    'remaining' => 'נותרו',
     'number_of_attendees' => 'מספר משתתפים',
     'terms_and_conditions' => 'תנאים והגבלות',
     'event_support_contact' => 'יצירת קשר לתמיכה באירוע',

--- a/resources/lang/it/messages.php
+++ b/resources/lang/it/messages.php
@@ -264,6 +264,7 @@ return [
     'customer' => 'Cliente',
     'transaction_reference' => 'Riferimento transazione',
     'total' => 'Totale',
+    'remaining' => 'Rimanenti',
     'number_of_attendees' => 'Numero di partecipanti',
     'terms_and_conditions' => 'Termini e condizioni',
     'event_support_contact' => 'Contatto supporto evento',

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -261,6 +261,7 @@ return [
     'customer' => 'Klant',
     'transaction_reference' => 'Transactiereferentie',
     'total' => 'Totaal',
+    'remaining' => 'Resterend',
     'number_of_attendees' => 'Aantal deelnemers',
     'terms_and_conditions' => 'Algemene voorwaarden',
     'event_support_contact' => 'Evenement support contact',

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -262,6 +262,7 @@ return [
     'customer' => 'Cliente',
     'transaction_reference' => 'Referência da transação',
     'total' => 'Total',
+    'remaining' => 'Restantes',
     'number_of_attendees' => 'Número de participantes',
     'terms_and_conditions' => 'Termos e condições',
     'event_support_contact' => 'Contato de suporte do evento',

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -167,6 +167,40 @@
                                                         <span class="ml-2 inline-flex items-center rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-200">{{ __('messages.recurring') }}</span>
                                                     @endif
                                                 </div>
+                                                @if ($event->tickets_enabled && $event->tickets->isNotEmpty())
+                                                    @php
+                                                        $hasLimitedTickets = $event->hasLimitedTickets();
+                                                        $totalTicketCount = $hasLimitedTickets ? $event->getTotalTicketQuantity() : null;
+                                                        $remainingTicketCount = $event->getRemainingTicketQuantity();
+                                                        $remainingTicketValue = $hasLimitedTickets ? max($remainingTicketCount ?? 0, 0) : null;
+                                                        $totalTicketLabel = $hasLimitedTickets ? number_format($totalTicketCount) : __('messages.unlimited');
+                                                        $remainingTicketLabel = $hasLimitedTickets ? number_format($remainingTicketValue) : __('messages.unlimited');
+                                                        $remainingBadgeClasses = 'inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200';
+
+                                                        if ($hasLimitedTickets) {
+                                                            if ($remainingTicketValue === 0) {
+                                                                $remainingBadgeClasses = 'inline-flex items-center gap-2 rounded-full bg-red-50 px-3 py-1 text-red-700 dark:bg-red-900/40 dark:text-red-200';
+                                                            } elseif ($remainingTicketValue <= 5) {
+                                                                $remainingBadgeClasses = 'inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200';
+                                                            }
+                                                        }
+                                                    @endphp
+                                                    <div class="mt-3 flex flex-wrap items-center gap-2 text-xs font-semibold">
+                                                        <span class="inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-blue-700 dark:bg-blue-900/40 dark:text-blue-200">
+                                                            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5a.75.75 0 01.75.75v3a2.25 2.25 0 010 4.5v3a.75.75 0 01-.75.75H3.75a.75.75 0 01-.75-.75v-3a2.25 2.25 0 010-4.5v-3a.75.75 0 01.75-.75z" />
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 5.25v13.5m6-13.5v13.5" />
+                                                            </svg>
+                                                            <span class="tracking-wide">{{ __('messages.total') }} {{ __('messages.tickets') }}: <span class="text-sm font-bold">{{ $totalTicketLabel }}</span></span>
+                                                        </span>
+                                                        <span class="{{ $remainingBadgeClasses }}">
+                                                            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                                                            </svg>
+                                                            <span class="tracking-wide">{{ __('messages.remaining') }} {{ __('messages.tickets') }}: <span class="text-sm font-bold">{{ $remainingTicketLabel }}</span></span>
+                                                        </span>
+                                                    </div>
+                                                @endif
                                             </td>
                                             <td class="px-6 py-4 align-top">
                                                 <div class="text-sm text-gray-700 dark:text-gray-200">


### PR DESCRIPTION
## Summary
- add helper methods on events to detect limited inventory, compute tickets sold, and remaining quantities
- surface total and remaining ticket badges on the events overview so organizers can quickly assess availability
- add translation strings for the new remaining label across supported locales

## Testing
- not run (composer install requires a GitHub token in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d2b1674124832e8f82166b830d411b