### PR TITLE
Add contacts overview page

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -3,7 +3,7 @@
     $venues = isset($venues) ? $venues : collect();
     $curators = isset($curators) ? $curators : collect();
 
-    $scheduleRoutes = ['role.pages', 'role.venues', 'role.curators', 'role.talent', 'role.view_admin'];
+    $scheduleRoutes = ['role.pages', 'role.venues', 'role.curators', 'role.talent', 'role.contacts', 'role.view_admin'];
     $schedulesActive = false;
     foreach ($scheduleRoutes as $routeName) {
         if (request()->routeIs($routeName)) {
@@ -212,6 +212,16 @@
                                     @endforeach
                                 </ul>
                             @endif
+                        </li>
+                        <li>
+                            <a href="{{ route('role.contacts') }}"
+                                class="group flex gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.contacts') ? 'bg-gray-800 text-white' : '' }}">
+                                <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="{{ request()->routeIs('role.contacts') ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 5.25h15a.75.75 0 01.75.75v12.75a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75V6a.75.75 0 01.75-.75z" />
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h4.5M8.25 15.75H12" />
+                                </svg>
+                                {{ __('messages.contacts') }}
+                            </a>
                         </li>
                     </ul>
                 </li>

--- a/resources/views/role/contacts.blade.php
+++ b/resources/views/role/contacts.blade.php
@@ -1,0 +1,103 @@
+<x-app-admin-layout>
+    <div class="py-12">
+        <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <h1 class="text-3xl font-semibold tracking-tight text-gray-900 dark:text-gray-100">{{ __('messages.contacts') }}</h1>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ __('messages.contacts_help') }}</p>
+                </div>
+            </div>
+
+            @php
+                $typeOrder = $typeOrder ?? [];
+            @endphp
+
+            @if ($hasContacts)
+                @foreach ($typeOrder as $type)
+                    @php
+                        $contacts = collect(($contactsByType ?? collect())->get($type, []));
+                        $label = $typeLabels[$type] ?? ucfirst($type);
+                    @endphp
+
+                    @if ($contacts->isNotEmpty())
+                        <div class="mt-12">
+                            <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ $label }}</h2>
+
+                            <div class="mt-4 overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg dark:ring-white/10">
+                                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                    <thead class="bg-gray-50 dark:bg-gray-900/60">
+                                        <tr>
+                                            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                                {{ __('messages.name') }}
+                                            </th>
+                                            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                                {{ __('messages.email') }}
+                                            </th>
+                                            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                                {{ __('messages.phone') }}
+                                            </th>
+                                            <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-gray-100">
+                                                {{ __('messages.role') }}
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+                                        @foreach ($contacts as $entry)
+                                            @php
+                                                $role = $entry['role'];
+                                                $contact = $entry['contact'];
+                                                $roleUrl = route('role.view_admin', ['subdomain' => $role->subdomain, 'tab' => 'schedule']);
+                                            @endphp
+                                            <tr class="transition-colors duration-150 hover:bg-gray-50 dark:hover:bg-gray-700/60">
+                                                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 dark:text-gray-100">
+                                                    @if (!empty($contact['name']))
+                                                        {{ $contact['name'] }}
+                                                    @else
+                                                        <span class="text-gray-400 dark:text-gray-500">—</span>
+                                                    @endif
+                                                </td>
+                                                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 dark:text-gray-100">
+                                                    @if (!empty($contact['email']))
+                                                        <a href="mailto:{{ $contact['email'] }}" class="text-[#4E81FA] hover:underline break-words">{{ $contact['email'] }}</a>
+                                                    @else
+                                                        <span class="text-gray-400 dark:text-gray-500">—</span>
+                                                    @endif
+                                                </td>
+                                                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 dark:text-gray-100">
+                                                    @if (!empty($contact['phone']))
+                                                        <a href="tel:{{ $contact['phone'] }}" class="text-[#4E81FA] hover:underline">{{ $contact['phone'] }}</a>
+                                                    @else
+                                                        <span class="text-gray-400 dark:text-gray-500">—</span>
+                                                    @endif
+                                                </td>
+                                                <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-900 dark:text-gray-100">
+                                                    <div class="flex flex-col">
+                                                        <a href="{{ $roleUrl }}" class="font-semibold text-[#4E81FA] hover:underline">
+                                                            {{ $role->getDisplayName(false) }}
+                                                        </a>
+                                                        <span class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ __('messages.' . $role->type) }}</span>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    @endif
+                @endforeach
+            @else
+                <div class="mt-12 flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-300 bg-white p-12 text-center dark:border-gray-700 dark:bg-gray-800">
+                    <div class="flex h-14 w-14 items-center justify-center rounded-full bg-[#4E81FA]/10">
+                        <svg class="h-6 w-6 text-[#4E81FA]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 4.5h15a.75.75 0 01.75.75v13.5a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75V5.25a.75.75 0 01.75-.75z" />
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 7.5h9M7.5 12h5.25" />
+                        </svg>
+                    </div>
+                    <h3 class="mt-6 text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('messages.no_contacts_added') }}</h3>
+                    <p class="mt-2 max-w-md text-sm text-gray-600 dark:text-gray-400">{{ __('messages.contacts_help') }}</p>
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-admin-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -87,6 +87,7 @@ Route::middleware(['auth', 'verified'])->group(function ()
     Route::get('/manage/venues', [RoleController::class, 'venues'])->name('role.venues');
     Route::get('/manage/curators', [RoleController::class, 'curators'])->name('role.curators');
     Route::get('/manage/talent', [RoleController::class, 'talent'])->name('role.talent');
+    Route::get('/manage/contacts', [RoleController::class, 'contacts'])->name('role.contacts');
     Route::get('/new/{type}', [RoleController::class, 'create'])->name('new');
     Route::post('/validate_address', [RoleController::class, 'validateAddress'])->name('validate_address')->middleware('throttle:25,1440');
     Route::post('/store', [RoleController::class, 'store'])->name('role.store');

--- a/tests/Feature/RoleContactsTest.php
+++ b/tests/Feature/RoleContactsTest.php
@@ -103,4 +103,63 @@ class RoleContactsTest extends TestCase
 
         $this->assertSame([], $role->contacts);
     }
+
+    public function test_contacts_page_displays_role_contacts(): void
+    {
+        $user = User::factory()->create();
+
+        $venue = new Role([
+            'type' => 'venue',
+            'name' => 'Concert Hall',
+            'email' => 'venue@example.com',
+        ]);
+        $venue->subdomain = 'concert-hall';
+        $venue->user_id = $user->id;
+        $venue->contacts = [
+            ['name' => 'Venue Contact', 'email' => 'venue-contact@example.com', 'phone' => '555-1000'],
+        ];
+        $venue->save();
+        $venue->users()->attach($user->id, ['level' => 'owner']);
+
+        $curator = new Role([
+            'type' => 'curator',
+            'name' => 'Event Collective',
+            'email' => 'curator@example.com',
+        ]);
+        $curator->subdomain = 'event-collective';
+        $curator->user_id = $user->id;
+        $curator->contacts = [
+            ['name' => 'Curator Contact', 'email' => 'curator-contact@example.com'],
+        ];
+        $curator->save();
+        $curator->users()->attach($user->id, ['level' => 'owner']);
+
+        $talent = new Role([
+            'type' => 'talent',
+            'name' => 'Headline Artist',
+            'email' => 'talent@example.com',
+        ]);
+        $talent->subdomain = 'headline-artist';
+        $talent->user_id = $user->id;
+        $talent->contacts = [
+            ['name' => 'Talent Contact', 'phone' => '555-2000'],
+        ];
+        $talent->save();
+        $talent->users()->attach($user->id, ['level' => 'owner']);
+
+        $this->actingAs($user);
+
+        $response = $this->get(route('role.contacts'));
+
+        $response->assertOk();
+        $response->assertSeeText(__('messages.venues'));
+        $response->assertSeeText(__('messages.curators'));
+        $response->assertSeeText(__('messages.contacts'));
+        $response->assertSeeText('Venue Contact');
+        $response->assertSee('venue-contact@example.com');
+        $response->assertSee('555-1000');
+        $response->assertSeeText('Curator Contact');
+        $response->assertSeeText('Talent Contact');
+        $response->assertSee('555-2000');
+    }
 }


### PR DESCRIPTION
## Summary
- add a `contacts` management route and controller action that aggregates contacts from venue, curator, and talent pages for the signed-in user
- create a dedicated admin contacts Blade view that groups contacts by role type with quick mail and phone links
- surface the contacts view in the schedules navigation and cover it with a feature test

## Testing
- not run (composer install prompts for a GitHub token, preventing dependency installation)

------
https://chatgpt.com/codex/tasks/task_e_68d34e2a2218832ebec8b22178596de9