### PR TITLE
Fix event overview and detail links to use public URLs

### DIFF
--- a/resources/views/event/view.blade.php
+++ b/resources/views/event/view.blade.php
@@ -6,7 +6,7 @@
         $talentNames = $talents->map->translatedName()->implode(', ');
         $curatorNames = $curators->map->translatedName()->implode(', ');
         $hasTickets = $event->tickets_enabled && $event->tickets->count() > 0;
-        $guestUrl = $event->getGuestUrl();
+        $guestUrl = $event->getGuestUrl(false, null, null, true);
         $cleanGuestUrl = $guestUrl ? \App\Utils\UrlUtils::clean($guestUrl) : null;
     @endphp
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -34,8 +34,6 @@
             ];
         })->values();
 
-        $eventViewRouteName = 'events.view';
-        $eventViewRouteExists = \Illuminate\Support\Facades\Route::has($eventViewRouteName);
     @endphp
 
     <div class="py-5">
@@ -221,23 +219,16 @@
                                             <td class="px-6 py-4 align-top">
                                                 <div class="flex items-center justify-end space-x-3">
                                                     @php
-                                                        $eventViewUrl = null;
-
-                                                        if ($eventViewRouteExists ?? false) {
-                                                            $eventViewUrl = rescue(
-                                                                fn () => route($eventViewRouteName, ['hash' => $hashedId]),
-                                                                null,
-                                                                false
-                                                            );
-
-                                                            if (! $eventViewUrl) {
-                                                                $eventViewRouteExists = false;
-                                                            }
-                                                        }
+                                                        $eventGuestUrl = rescue(
+                                                            fn () => $event->getGuestUrl(false, null, null, true),
+                                                            null,
+                                                            false
+                                                        );
                                                     @endphp
 
-                                                    @if ($eventViewUrl)
-                                                        <a href="{{ $eventViewUrl }}" class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{{ __('messages.view') }}</a>
+                                                    @if ($eventGuestUrl)
+                                                        <a href="{{ $eventGuestUrl }}" target="_blank" rel="noopener noreferrer"
+                                                           class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300">{{ __('messages.view_event') }}</a>
                                                     @endif
                                                     @if ($canEdit)
                                                         <a href="{{ route('event.edit_admin', ['hash' => $hashedId]) }}"


### PR DESCRIPTION
## Summary
- ensure the admin event detail view builds its "View Event" link using the public guest URL slug
- update the events overview actions to open the public guest page instead of the internal admin route

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d36462ad54832e828a16f56077bad4