### PR TITLE
chore: bump version to 2.0.2b

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,6 @@ jobs:
           draft: false
           prerelease: false
           title: "Latest Release"
-          automatic_release_tag: "2.0.1b"
+          automatic_release_tag: "2.0.2b"
           files: |
             eventschedule.zip

--- a/config/self-update.php
+++ b/config/self-update.php
@@ -28,7 +28,7 @@ return [
     |
     */
 
-    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '2.0.1b'),
+    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '2.0.2b'),
 
     'github_defaults' => [
         'vendor' => $defaultGithubVendor,


### PR DESCRIPTION
## Summary
- update the default installed version in the self-update configuration to 2.0.2b
- align the release workflow tag with version 2.0.2b

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d37073023c832e927be41b52775d2e