### PR TITLE
Handle missing user name when creating roles

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -824,11 +824,27 @@ class RoleController extends Controller
         $role->background_colors = ColorUtils::randomGradient();
         $role->background_image = ColorUtils::randomBackgroundImage();
         $role->background_rotation = rand(0, 359);
-        $role->timezone = auth()->user()->timezone;
-        $role->language_code = auth()->user()->language_code;
+        $user = auth()->user();
+
+        $role->timezone = data_get($user, 'timezone', config('app.timezone'));
+        $role->language_code = data_get($user, 'language_code', config('app.locale'));
 
         if ($role->type == 'talent') {
-            $role->name = auth()->user()->name;
+            $name = data_get($user, 'name');
+
+            if (! is_string($name) || trim($name) === '') {
+                $firstName = data_get($user, 'first_name');
+                $lastName = data_get($user, 'last_name');
+
+                $parts = array_filter([
+                    is_string($firstName) ? trim($firstName) : null,
+                    is_string($lastName) ? trim($lastName) : null,
+                ]);
+
+                $name = implode(' ', $parts);
+            }
+
+            $role->name = is_string($name) ? trim($name) : '';
         }
 
         // Header images


### PR DESCRIPTION
## Summary
- safeguard role creation defaults by pulling user timezone and language via data_get with sensible fallbacks
- derive the initial talent role name from available user attributes without assuming a name property exists

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ee6f59e1d8832eb47d8d00762feed8