### PR TITLE
Fix option name extraction for JSON data

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2222,18 +2222,6 @@ class RoleController extends Controller
         }
 
         if (is_object($item)) {
-            foreach (['name', 'value', 'label', 'title'] as $key) {
-                if (property_exists($item, $key)) {
-                    $value = $item->{$key};
-
-                    $candidate = $this->extractStringCandidate($value);
-
-                    if (is_string($candidate) && trim($candidate) !== '') {
-                        return $candidate;
-                    }
-                }
-            }
-
             $item = get_object_vars($item);
         }
 
@@ -2245,6 +2233,14 @@ class RoleController extends Controller
                     if (is_string($candidate) && trim($candidate) !== '') {
                         return $candidate;
                     }
+                }
+            }
+
+            foreach ($item as $value) {
+                $candidate = $this->extractStringCandidate($value);
+
+                if (is_string($candidate) && trim($candidate) !== '') {
+                    return $candidate;
                 }
             }
 


### PR DESCRIPTION
## Summary
- normalize decoded JSON option data into arrays before reading their metadata
- add a recursive fallback when searching for option labels to handle nested structures
- prevent undefined property notices when option entries are missing a name attribute

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee7462a588832e854012d5aee609e8