### PR TITLE
Decode JSON configuration files as associative arrays

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2186,7 +2186,7 @@ class RoleController extends Controller
             return [];
         }
 
-        $data = json_decode($contents);
+        $data = json_decode($contents, true);
 
         if (json_last_error() !== JSON_ERROR_NONE || ! is_array($data)) {
             return [];


### PR DESCRIPTION
## Summary
- decode role asset JSON files into associative arrays to avoid property access notices when building option lists

## Testing
- php -l app/Http/Controllers/RoleController.php

------
https://chatgpt.com/codex/tasks/task_e_68ee7640b740832e92f04114831090ce