### PR TITLE
Decode role assets as arrays

### DIFF
--- a/app/Utils/ColorUtils.php
+++ b/app/Utils/ColorUtils.php
@@ -11,10 +11,6 @@ class ColorUtils
         $gradientOptions = [];
 
         foreach ($gradients as $gradient) {
-            if (is_object($gradient)) {
-                $gradient = get_object_vars($gradient);
-            }
-
             if (is_array($gradient) && isset($gradient['colors']) && is_array($gradient['colors'])) {
                 $colors = array_values(array_filter($gradient['colors'], 'is_string'));
 
@@ -43,10 +39,6 @@ class ColorUtils
         $backgroundOptions = [];
 
         foreach ($backgrounds as $background) {
-            if (is_object($background)) {
-                $background = get_object_vars($background);
-            }
-
             if (is_array($background) && isset($background['name']) && is_string($background['name'])) {
                 $backgroundOptions[] = $background['name'];
             } elseif (is_string($background) && trim($background) !== '') {
@@ -80,7 +72,7 @@ class ColorUtils
             return [];
         }
 
-        $data = json_decode($contents);
+        $data = json_decode($contents, true);
 
         if (json_last_error() !== JSON_ERROR_NONE || ! is_array($data)) {
             return [];


### PR DESCRIPTION
## Summary
- ensure role asset JSON files are decoded as arrays in `ColorUtils`
- rely on array handling when building random gradient and background options to avoid undefined property notices

## Testing
- php artisan test *(fails: vendor autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ee8023b058832e92624bc0cab67d92