### PR TITLE
Add logging around role asset parsing failures

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2148,12 +2148,22 @@ class RoleController extends Controller
             }
 
             if (! is_string($name)) {
+                $this->reportRoleAssetParsingIssue(
+                    'name_non_string',
+                    $item,
+                    new \RuntimeException('Role asset name was not a string')
+                );
                 continue;
             }
 
             $name = trim($name);
 
             if ($name === '') {
+                $this->reportRoleAssetParsingIssue(
+                    'name_empty',
+                    $item,
+                    new \RuntimeException('Role asset name was empty after trimming')
+                );
                 continue;
             }
 
@@ -2188,12 +2198,22 @@ class RoleController extends Controller
             }
 
             if (! is_string($name)) {
+                $this->reportRoleAssetParsingIssue(
+                    'gradient_name_non_string',
+                    $item,
+                    new \RuntimeException('Role asset gradient name was not a string')
+                );
                 continue;
             }
 
             $name = trim($name);
 
             if ($name === '') {
+                $this->reportRoleAssetParsingIssue(
+                    'gradient_name_empty',
+                    $item,
+                    new \RuntimeException('Role asset gradient name was empty after trimming')
+                );
                 continue;
             }
 
@@ -2205,6 +2225,11 @@ class RoleController extends Controller
             }
 
             if (empty($colors)) {
+                $this->reportRoleAssetParsingIssue(
+                    'gradient_colors_empty',
+                    $item,
+                    new \RuntimeException('Role asset gradient colors were empty')
+                );
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- add defensive logging when role asset name or gradient data is missing or malformed
- ensure gradient color parsing issues are surfaced with explicit runtime context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee82ce72b0832e895919b2cacac37c