### PR TITLE
Normalize user data when initializing talent roles

### DIFF
--- a/tests/Unit/RoleControllerUserNormalizationTest.php
+++ b/tests/Unit/RoleControllerUserNormalizationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\RoleController;
+use App\Repos\EventRepo;
+use Illuminate\Contracts\Support\Arrayable;
+use Mockery;
+use Tests\TestCase;
+
+class RoleControllerUserNormalizationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testNormalizeAuthenticatedUserHandlesStdClassWithoutProperties(): void
+    {
+        $controller = new RoleController(Mockery::mock(EventRepo::class));
+        $user = (object) [
+            'first_name' => 'Ada',
+            'last_name' => 'Lovelace',
+        ];
+
+        $normalized = $this->invokeNormalizeUser($controller, $user);
+
+        $this->assertSame('Ada', $normalized['first_name']);
+        $this->assertSame('Lovelace', $normalized['last_name']);
+        $this->assertArrayNotHasKey('name', $normalized);
+    }
+
+    public function testNormalizeAuthenticatedUserHandlesArrayable(): void
+    {
+        $controller = new RoleController(Mockery::mock(EventRepo::class));
+        $user = new class implements Arrayable {
+            public function toArray()
+            {
+                return [
+                    'name' => 'Grace Hopper',
+                    'timezone' => 'UTC',
+                ];
+            }
+        };
+
+        $normalized = $this->invokeNormalizeUser($controller, $user);
+
+        $this->assertSame('Grace Hopper', $normalized['name']);
+        $this->assertSame('UTC', $normalized['timezone']);
+    }
+
+    public function testNormalizeAuthenticatedUserHandlesNull(): void
+    {
+        $controller = new RoleController(Mockery::mock(EventRepo::class));
+
+        $normalized = $this->invokeNormalizeUser($controller, null);
+
+        $this->assertSame([], $normalized);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function invokeNormalizeUser(RoleController $controller, $user): array
+    {
+        $method = new \ReflectionMethod($controller, 'normalizeAuthenticatedUser');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $user);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize the authenticated user into an array before seeding a new talent role so missing properties no longer trigger notices
- add a helper on the controller to safely convert arrayable, array, and object user representations into a consistent structure
- cover the normalization helper with unit tests for stdClass, Arrayable, and null inputs

## Testing
- ./vendor/bin/phpunit --filter RoleControllerUserNormalizationTest *(fails in container: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68efc8fc06ec832ea928dd349c156d15