### PR TITLE
Gracefully handle role asset option parsing failures

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2215,7 +2215,7 @@ class RoleController extends Controller
         } catch (\Throwable $e) {
             $this->logRoleAssetPreparationFailure($context, $relativePath, $e);
 
-            throw $e;
+            return [];
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent role asset option loading from aborting when asset data is malformed by returning empty defaults after logging the error

## Testing
- composer test *(fails: Command "test" is not defined.)*
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f07a3c6730832e9b8ecf9d1e531702