### PR TITLE
Improve role asset loading resilience

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2207,6 +2207,10 @@ class RoleController extends Controller
      */
     private function loadRoleAssetOptions(string $relativePath, callable $processor, string $context)
     {
+        set_error_handler(function ($severity, $message, $file, $line) {
+            throw new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
         try {
             $data = $this->decodeJsonFile($relativePath);
             $data = $this->normalizeRoleAssetDataset($data);
@@ -2216,6 +2220,8 @@ class RoleController extends Controller
             $this->logRoleAssetPreparationFailure($context, $relativePath, $e);
 
             return [];
+        } finally {
+            restore_error_handler();
         }
     }
 
@@ -2510,6 +2516,7 @@ class RoleController extends Controller
      */
     private function prepareNameOptions($items): array
     {
+        $items = $this->forceRoleAssetDatasetToArray($items);
         $options = [];
 
         foreach ($this->normalizeRoleAssetSequence($items, 'name_option') as $entry) {
@@ -2582,6 +2589,7 @@ class RoleController extends Controller
      */
     private function prepareGradientOptions($items): array
     {
+        $items = $this->forceRoleAssetDatasetToArray($items);
         $options = [];
 
         foreach ($this->normalizeRoleAssetSequence($items, 'gradient_option') as $entry) {
@@ -2676,6 +2684,7 @@ class RoleController extends Controller
      */
     private function prepareFontOptions($items): array
     {
+        $items = $this->forceRoleAssetDatasetToArray($items);
         $options = [];
 
         foreach ($this->normalizeRoleAssetSequence($items, 'font_option') as $entry) {

--- a/app/Utils/ColorUtils.php
+++ b/app/Utils/ColorUtils.php
@@ -7,44 +7,53 @@ class ColorUtils
     public static function randomGradient()
     {
         $gradients = self::decodeJsonFile('storage/gradients.json');
-
         $gradientOptions = [];
 
-        foreach ($gradients as $gradient) {
-            if (is_array($gradient) && isset($gradient['colors']) && is_array($gradient['colors'])) {
-                $colors = array_values(array_filter($gradient['colors'], 'is_string'));
+        foreach (self::yieldRoleAssetItems($gradients) as $gradient) {
+            $name = self::determineRoleAssetName($gradient);
+            $colors = self::extractColors($gradient);
 
-                if (! empty($colors)) {
-                    $gradientOptions[] = join(', ', $colors);
-                }
-            } elseif (is_string($gradient) && trim($gradient) !== '') {
-                // Some legacy data stores gradients as simple comma separated strings.
-                $gradientOptions[] = $gradient;
+            if ($name === null || empty($colors)) {
+                continue;
             }
+
+            $key = join(', ', $colors);
+
+            if ($key === '') {
+                continue;
+            }
+
+            $gradientOptions[$key] = $key;
         }
 
         if (empty($gradientOptions)) {
             return '#1A2980, #26D0CE';
         }
 
-        $random = array_rand($gradientOptions);
+        $values = array_values(array_unique($gradientOptions));
+        $random = array_rand($values);
 
-        return $gradientOptions[$random];
+        return $values[$random];
     }
 
     public static function randomBackgroundImage()
     {
         $backgrounds = self::decodeJsonFile('storage/backgrounds.json');
-
         $backgroundOptions = [];
 
-        foreach ($backgrounds as $background) {
-            if (is_array($background) && isset($background['name']) && is_string($background['name'])) {
-                $backgroundOptions[] = $background['name'];
-            } elseif (is_string($background) && trim($background) !== '') {
-                $backgroundOptions[] = $background;
+        foreach (self::yieldRoleAssetItems($backgrounds) as $background) {
+            $name = self::determineRoleAssetName($background);
+
+            if ($name === null) {
+                continue;
             }
+
+            $backgroundOptions[] = $name;
         }
+
+        $backgroundOptions = array_values(array_unique(array_filter($backgroundOptions, function ($value) {
+            return is_string($value) && trim($value) !== '';
+        })));
 
         if (empty($backgroundOptions)) {
             return '';
@@ -79,5 +88,210 @@ class ColorUtils
         }
 
         return $data;
+    }
+
+    private static function yieldRoleAssetItems($items): iterable
+    {
+        $normalized = self::normalizeDecodedJsonStructure($items);
+
+        if ($normalized === null) {
+            return;
+        }
+
+        if (! is_array($normalized)) {
+            yield $normalized;
+
+            return;
+        }
+
+        foreach ($normalized as $item) {
+            yield $item;
+        }
+    }
+
+    private static function normalizeDecodedJsonStructure($value, int $depth = 0)
+    {
+        if ($depth > 20) {
+            return [];
+        }
+
+        if ($value instanceof \JsonSerializable) {
+            try {
+                $value = $value->jsonSerialize();
+            } catch (\Throwable $e) {
+                return [];
+            }
+        }
+
+        if ($value instanceof \Traversable) {
+            try {
+                $value = iterator_to_array($value);
+            } catch (\Throwable $e) {
+                return [];
+            }
+        }
+
+        if (is_object($value)) {
+            try {
+                $value = get_object_vars($value);
+            } catch (\Throwable $e) {
+                return [];
+            }
+        }
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        foreach ($value as $key => $item) {
+            $value[$key] = self::normalizeDecodedJsonStructure($item, $depth + 1);
+        }
+
+        return $value;
+    }
+
+    private static function determineRoleAssetName($item, int $depth = 0): ?string
+    {
+        if ($depth > 10) {
+            return null;
+        }
+
+        if ($item instanceof \JsonSerializable) {
+            try {
+                $item = $item->jsonSerialize();
+            } catch (\Throwable $e) {
+                return null;
+            }
+        }
+
+        if ($item instanceof \Traversable) {
+            try {
+                $item = iterator_to_array($item);
+            } catch (\Throwable $e) {
+                return null;
+            }
+        }
+
+        if (is_object($item)) {
+            try {
+                $item = get_object_vars($item);
+            } catch (\Throwable $e) {
+                return null;
+            }
+        }
+
+        if (is_string($item)) {
+            $item = trim($item);
+
+            return $item === '' ? null : $item;
+        }
+
+        if (is_scalar($item)) {
+            $string = trim((string) $item);
+
+            return $string === '' ? null : $string;
+        }
+
+        if (is_array($item)) {
+            foreach (['name', 'value', 'label', 'title', 'id', 'slug'] as $key) {
+                if (array_key_exists($key, $item)) {
+                    $candidate = self::determineRoleAssetName($item[$key], $depth + 1);
+
+                    if (is_string($candidate) && trim($candidate) !== '') {
+                        return $candidate;
+                    }
+                }
+            }
+
+            foreach ($item as $value) {
+                $candidate = self::determineRoleAssetName($value, $depth + 1);
+
+                if (is_string($candidate) && trim($candidate) !== '') {
+                    return $candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function extractColors($item, int $depth = 0): array
+    {
+        if ($depth > 10) {
+            return [];
+        }
+
+        if ($item instanceof \JsonSerializable) {
+            try {
+                $item = $item->jsonSerialize();
+            } catch (\Throwable $e) {
+                return [];
+            }
+        }
+
+        if ($item instanceof \Traversable) {
+            try {
+                $item = iterator_to_array($item);
+            } catch (\Throwable $e) {
+                return [];
+            }
+        }
+
+        if (is_object($item)) {
+            try {
+                $item = get_object_vars($item);
+            } catch (\Throwable $e) {
+                return [];
+            }
+        }
+
+        if (is_string($item) || is_numeric($item)) {
+            $candidate = trim((string) $item);
+
+            return self::isColorString($candidate) ? [$candidate] : [];
+        }
+
+        if (! is_array($item)) {
+            return [];
+        }
+
+        $colors = [];
+
+        foreach ($item as $value) {
+            $extracted = self::extractColors($value, $depth + 1);
+
+            if (! empty($extracted)) {
+                $colors = array_merge($colors, $extracted);
+            }
+        }
+
+        if (! empty($colors)) {
+            return array_values(array_unique(array_filter($colors, function ($value) {
+                return is_string($value) && trim($value) !== '';
+            })));
+        }
+
+        return [];
+    }
+
+    private static function isColorString(string $value): bool
+    {
+        if ($value === '') {
+            return false;
+        }
+
+        if ($value[0] === '#') {
+            return true;
+        }
+
+        if (preg_match('/^(?:rgb|rgba|hsl|hsla)\s*\(/i', $value)) {
+            return true;
+        }
+
+        if (preg_match('/^[0-9a-f]{3,8}$/i', $value)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Unit/ColorUtilsTest.php
+++ b/tests/Unit/ColorUtilsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Utils\ColorUtils;
+use Tests\TestCase;
+
+class ColorUtilsTest extends TestCase
+{
+    public function testDetermineRoleAssetNameHandlesStdClass(): void
+    {
+        $method = new \ReflectionMethod(ColorUtils::class, 'determineRoleAssetName');
+        $method->setAccessible(true);
+
+        $value = (object) [
+            'meta' => (object) ['title' => 'Ignored'],
+            'label' => (object) ['text' => 'Display'],
+            'name' => (object) ['value' => 'Background_Name'],
+        ];
+
+        $result = $method->invoke(null, $value, 0);
+
+        $this->assertSame('Background_Name', $result);
+    }
+
+    public function testExtractColorsHandlesNestedStructures(): void
+    {
+        $method = new \ReflectionMethod(ColorUtils::class, 'extractColors');
+        $method->setAccessible(true);
+
+        $value = (object) [
+            'info' => 'unused',
+            'colors' => [
+                '#123456',
+                (object) ['primary' => '#abcdef', 'secondary' => 'not-a-color'],
+                ['nested' => ['#FEDCBA']],
+            ],
+        ];
+
+        $result = $method->invoke(null, $value, 0);
+
+        $this->assertSame(['#123456', '#abcdef', '#FEDCBA'], $result);
+    }
+}

--- a/tests/Unit/RoleControllerAssetOptionsTest.php
+++ b/tests/Unit/RoleControllerAssetOptionsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\RoleController;
+use App\Repos\EventRepo;
+use Mockery;
+use Tests\TestCase;
+
+class RoleControllerAssetOptionsTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testLoadRoleAssetOptionsHandlesUndefinedPropertyGracefully(): void
+    {
+        $controller = new RoleController(Mockery::mock(EventRepo::class));
+        $method = new \ReflectionMethod($controller, 'loadRoleAssetOptions');
+        $method->setAccessible(true);
+
+        $relativePath = 'storage/test-assets.json';
+        $absolutePath = base_path($relativePath);
+
+        if (! is_dir(dirname($absolutePath))) {
+            mkdir(dirname($absolutePath), 0777, true);
+        }
+
+        file_put_contents($absolutePath, json_encode([['name' => 'sample']]));
+
+        $result = $method->invoke($controller, $relativePath, function () {
+            $object = new \stdClass();
+
+            return $object->name; // Triggers Undefined property notice converted to ErrorException.
+        }, 'unit.test');
+
+        $this->assertSame([], $result);
+
+        unlink($absolutePath);
+    }
+}


### PR DESCRIPTION
## Summary
- convert PHP notices into caught exceptions when building role asset options so invalid data no longer crashes the controller
- coerce asset datasets to arrays before preparing dropdown choices and harden the ColorUtils helpers that read JSON assets
- add unit coverage for the new parsing logic and the graceful failure path

## Testing
- unable to run phpunit (composer install fails because GitHub downloads require credentials in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f07f64161c832ebf027ce4a94d7781