### PR TITLE
Normalize group payloads before rendering subschedule form

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -27,6 +27,7 @@ use App\Models\EventRole;
 use App\Utils\UrlUtils;
 use App\Utils\ColorUtils;
 use App\Utils\GeminiUtils;
+use App\Support\GroupPayloadNormalizer;
 use Carbon\Carbon;
 
 class RoleController extends Controller
@@ -2503,42 +2504,7 @@ class RoleController extends Controller
      */
     private function normalizeGroupInput($groups): array
     {
-        $normalized = $this->normalizeDecodedJsonStructure($groups);
-
-        if (! is_array($normalized)) {
-            $normalized = (array) $normalized;
-        }
-
-        $result = [];
-
-        foreach ($normalized as $key => $group) {
-            if ($group instanceof Arrayable) {
-                $group = $group->toArray();
-            } elseif (is_object($group)) {
-                try {
-                    $group = get_object_vars($group);
-                } catch (\Throwable $e) {
-                    report($e);
-                    $group = [];
-                }
-            } elseif (! is_array($group)) {
-                $group = is_scalar($group) ? ['name' => (string) $group] : [];
-            }
-
-            $name = isset($group['name']) && is_scalar($group['name']) ? trim((string) $group['name']) : '';
-            $nameEn = isset($group['name_en']) && is_scalar($group['name_en']) ? trim((string) $group['name_en']) : '';
-            $slug = isset($group['slug']) && is_scalar($group['slug']) ? trim((string) $group['slug']) : '';
-            $id = isset($group['id']) && is_scalar($group['id']) ? (string) $group['id'] : null;
-
-            $result[$key] = [
-                'id' => $id,
-                'name' => $name,
-                'name_en' => $nameEn,
-                'slug' => $slug,
-            ];
-        }
-
-        return $result;
+        return GroupPayloadNormalizer::forPersistence($groups);
     }
 
     /**

--- a/app/Support/GroupPayloadNormalizer.php
+++ b/app/Support/GroupPayloadNormalizer.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use JsonSerializable;
+use Throwable;
+use Traversable;
+
+class GroupPayloadNormalizer
+{
+    /**
+     * Normalize group input for persistence (controllers, requests, etc.).
+     *
+     * @param  mixed  $groups
+     * @return array<int|string, array{id: string|null, name: string, name_en: string, slug: string}>
+     */
+    public static function forPersistence($groups): array
+    {
+        $normalized = static::deepNormalize($groups);
+
+        if (! is_array($normalized)) {
+            $normalized = (array) $normalized;
+        }
+
+        $result = [];
+
+        foreach ($normalized as $key => $group) {
+            $groupArray = static::normalizeGroupEntry($group);
+
+            $result[$key] = [
+                'id' => static::nullableString($groupArray['id'] ?? null),
+                'name' => static::stringOrEmpty($groupArray['name'] ?? null),
+                'name_en' => static::stringOrEmpty($groupArray['name_en'] ?? null),
+                'slug' => static::stringOrEmpty($groupArray['slug'] ?? null),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Normalize group payloads for Blade views.
+     *
+     * @param  mixed  $groups
+     * @return array<int|string, array{id: string, name: string, name_en: string, slug: string}>
+     */
+    public static function forView($groups): array
+    {
+        $normalized = static::forPersistence($groups);
+        $result = [];
+
+        foreach ($normalized as $key => $group) {
+            $id = $group['id'];
+
+            if (! is_string($id) || $id === '') {
+                $id = is_scalar($key) ? (string) $key : '';
+            }
+
+            $result[$key] = [
+                'id' => $id,
+                'name' => $group['name'],
+                'name_en' => $group['name_en'],
+                'slug' => $group['slug'],
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  mixed  $value
+     * @param  int  $depth
+     * @return mixed
+     */
+    private static function deepNormalize($value, int $depth = 0)
+    {
+        if ($depth > 20) {
+            return [];
+        }
+
+        if ($value instanceof JsonSerializable) {
+            try {
+                $value = $value->jsonSerialize();
+            } catch (Throwable $e) {
+                return [];
+            }
+        }
+
+        if ($value instanceof Traversable) {
+            try {
+                $value = iterator_to_array($value);
+            } catch (Throwable $e) {
+                return [];
+            }
+        }
+
+        if ($value instanceof Collection) {
+            try {
+                $value = $value->all();
+            } catch (Throwable $e) {
+                return [];
+            }
+        }
+
+        if (is_object($value)) {
+            try {
+                $value = get_object_vars($value);
+            } catch (Throwable $e) {
+                return [];
+            }
+        }
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        foreach ($value as $key => $item) {
+            $value[$key] = static::deepNormalize($item, $depth + 1);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  mixed  $group
+     * @return array<string, mixed>
+     */
+    private static function normalizeGroupEntry($group): array
+    {
+        if ($group instanceof Arrayable) {
+            try {
+                $group = $group->toArray();
+            } catch (Throwable $e) {
+                report($e);
+                $group = [];
+            }
+        } elseif ($group instanceof Model) {
+            try {
+                $group = $group->toArray();
+            } catch (Throwable $e) {
+                report($e);
+                $group = [];
+            }
+        } elseif (is_object($group)) {
+            try {
+                $group = get_object_vars($group);
+            } catch (Throwable $e) {
+                report($e);
+                $group = [];
+            }
+        } elseif (! is_array($group)) {
+            $group = is_scalar($group)
+                ? ['name' => (string) $group]
+                : [];
+        }
+
+        return is_array($group) ? $group : [];
+    }
+
+    private static function nullableString($value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $string = trim((string) $value);
+
+        return $string === '' ? null : $string;
+    }
+
+    private static function stringOrEmpty($value): string
+    {
+        if (! is_scalar($value)) {
+            return '';
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/resources/views/role/edit.blade.php
+++ b/resources/views/role/edit.blade.php
@@ -1115,43 +1115,9 @@
                         <div class="mb-6">
                             <div id="groups-list">
                                 @php
-                                    $groups = $role->groups ?? [];
-                                    $rawGroups = old('groups', $groups);
-
-                                    if ($rawGroups instanceof \Illuminate\Support\Collection) {
-                                        $rawGroups = $rawGroups->all();
-                                    }
-
-                                    if ($rawGroups instanceof \Illuminate\Database\Eloquent\Collection) {
-                                        $rawGroups = $rawGroups->all();
-                                    }
-
-                                    if (! is_array($rawGroups)) {
-                                        $rawGroups = (array) $rawGroups;
-                                    }
-
-                                    $normalizedGroups = [];
-
-                                    foreach ($rawGroups as $key => $group) {
-                                        if ($group instanceof \Illuminate\Contracts\Support\Arrayable) {
-                                            $group = $group->toArray();
-                                        } elseif ($group instanceof \Illuminate\Database\Eloquent\Model) {
-                                            $group = $group->toArray();
-                                        } elseif (is_object($group)) {
-                                            $group = (array) $group;
-                                        } elseif (! is_array($group)) {
-                                            $group = [];
-                                        }
-
-                                        $groupId = $group['id'] ?? $key;
-
-                                        $normalizedGroups[$key] = [
-                                            'id' => is_scalar($groupId) ? (string) $groupId : $key,
-                                            'name' => isset($group['name']) && is_scalar($group['name']) ? (string) $group['name'] : '',
-                                            'name_en' => isset($group['name_en']) && is_scalar($group['name_en']) ? (string) $group['name_en'] : '',
-                                            'slug' => isset($group['slug']) && is_scalar($group['slug']) ? (string) $group['slug'] : '',
-                                        ];
-                                    }
+                                    $normalizedGroups = \App\Support\GroupPayloadNormalizer::forView(
+                                        old('groups', $role->groups ?? [])
+                                    );
                                 @endphp
                                 <div id="group-items">
                                     @foreach($normalizedGroups as $i => $group)

--- a/tests/Unit/GroupPayloadNormalizerTest.php
+++ b/tests/Unit/GroupPayloadNormalizerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\GroupPayloadNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class GroupPayloadNormalizerTest extends TestCase
+{
+    public function testForViewCastsStdClassWithoutName(): void
+    {
+        $groups = [
+            (object) ['id' => 5, 'slug' => 'main-stage'],
+            (object) ['slug' => 'vip'],
+        ];
+
+        $normalized = GroupPayloadNormalizer::forView($groups);
+
+        $this->assertSame([
+            0 => [
+                'id' => '5',
+                'name' => '',
+                'name_en' => '',
+                'slug' => 'main-stage',
+            ],
+            1 => [
+                'id' => '1',
+                'name' => '',
+                'name_en' => '',
+                'slug' => 'vip',
+            ],
+        ], $normalized);
+    }
+
+    public function testForPersistenceNormalizesScalars(): void
+    {
+        $groups = [
+            'Morning Set',
+            ['name' => 'Evening', 'name_en' => 'Evening', 'slug' => 'evening'],
+        ];
+
+        $normalized = GroupPayloadNormalizer::forPersistence($groups);
+
+        $this->assertSame([
+            0 => [
+                'id' => null,
+                'name' => 'Morning Set',
+                'name_en' => '',
+                'slug' => '',
+            ],
+            1 => [
+                'id' => null,
+                'name' => 'Evening',
+                'name_en' => 'Evening',
+                'slug' => 'evening',
+            ],
+        ], $normalized);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable GroupPayloadNormalizer to coerce dynamic role group payloads into predictable arrays
- reuse the normalizer inside RoleController and the role/edit Blade so stdClass payloads no longer trigger undefined property errors
- add unit coverage for the normalizer’s view and persistence transformations

## Testing
- vendor/bin/phpunit --filter GroupPayloadNormalizerTest *(fails: vendor dependencies are unavailable without composer install)*
- composer install --quiet *(fails: github.com/phpstan/extension-installer.git cannot be fetched in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0ecadba14832e9586d82bee83b5fa