### PR TITLE
Increase wait thresholds in Dusk tests

### DIFF
--- a/tests/Browser/GeneralTest.php
+++ b/tests/Browser/GeneralTest.php
@@ -28,7 +28,7 @@ class GeneralTest extends DuskTestCase
 
             // Log out
             $browser->press($name)
-                    ->waitForText('Log Out', 5)
+                    ->waitForText('Log Out', 15)
                     ->clickLink('Log Out')
                     ->waitForLocation('/login', 20)
                     ->assertPathIs('/login');

--- a/tests/Browser/Traits/AccountSetupTrait.php
+++ b/tests/Browser/Traits/AccountSetupTrait.php
@@ -30,7 +30,7 @@ trait AccountSetupTrait
     protected function createTestVenue(Browser $browser, string $name = 'Venue', string $address = '123 Test St'): void
     {
         $browser->visit('/new/venue')
-                ->waitForText('New Venue', 5)
+                ->waitForText('New Venue', 15)
                 ->clear('name')
                 ->type('name', $name)
                 ->pause(1000)
@@ -47,7 +47,7 @@ trait AccountSetupTrait
     protected function createTestTalent(Browser $browser, string $name = 'Talent'): void
     {
         $browser->visit('/new/talent')
-                ->waitForText('New Talent', 5)
+                ->waitForText('New Talent', 15)
                 ->clear('name')
                 ->type('name', $name)
                 ->pause(1000)
@@ -63,7 +63,7 @@ trait AccountSetupTrait
     protected function createTestCurator(Browser $browser, string $name = 'Curator'): void
     {
         $browser->visit('/new/curator')
-                ->waitForText('New Curator', 5)
+                ->waitForText('New Curator', 15)
                 ->clear('name')
                 ->type('name', $name)
                 ->pause(1000)


### PR DESCRIPTION
## Summary
- increase several Dusk waitForText timeouts in the account setup helpers to better accommodate slow environments
- extend the logout wait in the general browser test to reduce flakiness when running in CI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f15c885618832ebd0cc14932b8650d