### PR TITLE
Extend Dusk wait timeouts for role setup

### DIFF
--- a/tests/Browser/Traits/AccountSetupTrait.php
+++ b/tests/Browser/Traits/AccountSetupTrait.php
@@ -30,7 +30,7 @@ trait AccountSetupTrait
     protected function createTestVenue(Browser $browser, string $name = 'Venue', string $address = '123 Test St'): void
     {
         $browser->visit('/new/venue')
-                ->waitForText('New Venue', 5)
+                ->waitForText('Venue Details', 30)
                 ->clear('name')
                 ->type('name', $name)
                 ->pause(1000)
@@ -47,7 +47,7 @@ trait AccountSetupTrait
     protected function createTestTalent(Browser $browser, string $name = 'Talent'): void
     {
         $browser->visit('/new/talent')
-                ->waitForText('New Talent', 5)
+                ->waitForText('Talent Details', 30)
                 ->clear('name')
                 ->type('name', $name)
                 ->pause(1000)
@@ -63,7 +63,7 @@ trait AccountSetupTrait
     protected function createTestCurator(Browser $browser, string $name = 'Curator'): void
     {
         $browser->visit('/new/curator')
-                ->waitForText('New Curator', 5)
+                ->waitForText('Curator Details', 30)
                 ->clear('name')
                 ->type('name', $name)
                 ->pause(1000)


### PR DESCRIPTION
## Summary
- update the Dusk account setup helpers to wait for the new role creation headings before interacting with the forms
- increase the waits for the role creation headings to 30 seconds to better handle slower page loads

## Testing
- not run (UI tests require a browser environment)

------
https://chatgpt.com/codex/tasks/task_e_68f16310c620832e9ea2fad48e7f9679