### PR TITLE
Improve log level normalization and talent defaults

### DIFF
--- a/app/Support/Logging/LogLevelNormalizer.php
+++ b/app/Support/Logging/LogLevelNormalizer.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Support\Logging;
+
+use Monolog\Level;
+
+class LogLevelNormalizer
+{
+    /**
+     * @var array<string, bool>
+     */
+    private const VALID_LEVELS = [
+        'debug' => true,
+        'info' => true,
+        'notice' => true,
+        'warning' => true,
+        'error' => true,
+        'critical' => true,
+        'alert' => true,
+        'emergency' => true,
+    ];
+
+    public static function normalize($value, string $default): string
+    {
+        foreach (self::candidateStrings($value) as $candidate) {
+            $normalized = strtolower($candidate);
+
+            if (isset(self::VALID_LEVELS[$normalized])) {
+                return $normalized;
+            }
+
+            if (is_numeric($candidate)) {
+                $level = self::convertNumericLevel($candidate);
+
+                if ($level !== null) {
+                    return $level;
+                }
+            }
+
+            try {
+                $monologLevel = Level::fromName(strtoupper($candidate));
+
+                return strtolower($monologLevel->getName());
+            } catch (\Throwable $e) {
+                // Ignore invalid levels and try the next candidate.
+            }
+        }
+
+        return strtolower($default);
+    }
+
+    /**
+     * @return iterable<int, string>
+     */
+    private static function candidateStrings($value): iterable
+    {
+        if ($value === null) {
+            return [];
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $candidate) {
+                foreach (self::candidateStrings($candidate) as $nested) {
+                    yield $nested;
+                }
+            }
+
+            return;
+        }
+
+        if (is_string($value)) {
+            $value = trim($value);
+
+            if ($value === '') {
+                return [];
+            }
+
+            $decoded = json_decode($value, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                yield from self::candidateStrings($decoded);
+            }
+
+            foreach (explode(',', $value) as $part) {
+                $part = trim($part, " \t\n\r\0\x0B\"'");
+
+                if ($part !== '') {
+                    yield $part;
+                }
+            }
+
+            if ($value !== '') {
+                yield trim($value, " \t\n\r\0\x0B\"'");
+            }
+
+            return;
+        }
+
+        if (is_scalar($value)) {
+            $stringValue = trim((string) $value);
+
+            if ($stringValue !== '') {
+                yield $stringValue;
+            }
+        }
+    }
+
+    private static function convertNumericLevel($value): ?string
+    {
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        $intValue = (int) $value;
+
+        foreach (Level::cases() as $level) {
+            if ($level->value === $intValue) {
+                return strtolower($level->getName());
+            }
+        }
+
+        return null;
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Logging\LogLevelNormalizer;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -8,57 +9,7 @@ use Monolog\Processor\PsrLogMessageProcessor;
 $rawLogLevel = env('LOG_LEVEL');
 
 $normalizeLogLevel = static function (string $default) use ($rawLogLevel): string {
-    $value = $rawLogLevel;
-
-    if ($value === null || $value === '') {
-        return $default;
-    }
-
-    if (is_array($value)) {
-        foreach ($value as $candidate) {
-            if (is_string($candidate) && $candidate !== '') {
-                return $candidate;
-            }
-        }
-
-        return $default;
-    }
-
-    if (is_string($value)) {
-        $decoded = json_decode($value, true);
-
-        if (json_last_error() === JSON_ERROR_NONE) {
-            if (is_array($decoded)) {
-                foreach ($decoded as $candidate) {
-                    if (is_string($candidate) && $candidate !== '') {
-                        return $candidate;
-                    }
-                }
-            }
-
-            if (is_string($decoded) && $decoded !== '') {
-                return $decoded;
-            }
-        }
-
-        foreach (array_map('trim', explode(',', $value)) as $candidate) {
-            if ($candidate !== '') {
-                return $candidate;
-            }
-        }
-
-        $value = trim($value, " \t\n\r\0\x0B\"'");
-
-        return $value !== '' ? $value : $default;
-    }
-
-    if (is_scalar($value)) {
-        $value = (string) $value;
-
-        return $value !== '' ? $value : $default;
-    }
-
-    return $default;
+    return LogLevelNormalizer::normalize($rawLogLevel, $default);
 };
 
 $stackChannels = (static function ($value): array {

--- a/tests/Unit/LogLevelNormalizerTest.php
+++ b/tests/Unit/LogLevelNormalizerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Logging\LogLevelNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class LogLevelNormalizerTest extends TestCase
+{
+    /**
+     * @dataProvider providesValidCandidates
+     */
+    public function testNormalizeReturnsFirstValidLevel($value, string $expected): void
+    {
+        $this->assertSame($expected, LogLevelNormalizer::normalize($value, 'warning'));
+    }
+
+    public function providesValidCandidates(): array
+    {
+        return [
+            'string-level' => ['INFO', 'info'],
+            'json-array' => ['["error", "debug"]', 'error'],
+            'comma-separated' => [' notice , warning ', 'notice'],
+            'array-value' => [['', 'CRITICAL'], 'critical'],
+            'numeric-value' => [300, 'warning'],
+            'monolog-name' => ['EMERGENCY', 'emergency'],
+        ];
+    }
+
+    public function testNormalizeFallsBackToDefaultWhenNoValidValueFound(): void
+    {
+        $this->assertSame('warning', LogLevelNormalizer::normalize(['', null, ''], 'warning'));
+    }
+}

--- a/tests/Unit/RoleControllerUserNormalizationTest.php
+++ b/tests/Unit/RoleControllerUserNormalizationTest.php
@@ -60,6 +60,54 @@ class RoleControllerUserNormalizationTest extends TestCase
         $this->assertSame([], $normalized);
     }
 
+    public function testEnsureUserIdentityAttributesPopulatesStdClass(): void
+    {
+        $controller = new RoleController(Mockery::mock(EventRepo::class));
+        $role = new \App\Models\Role();
+        $role->name = 'Sample Talent';
+
+        $user = (object) [];
+        $userData = [
+            'first_name' => 'Sample',
+            'last_name' => 'Talent',
+            'email' => 'sample@example.test',
+        ];
+
+        $this->invokeEnsureUserIdentity($controller, $user, $userData, $role);
+
+        $this->assertSame('Sample Talent', $user->name);
+        $this->assertSame('Sample', $user->first_name);
+        $this->assertSame('Talent', $user->last_name);
+        $this->assertSame('sample@example.test', $user->email);
+    }
+
+    public function testEnsureUserIdentityAttributesDoesNotOverrideExistingValues(): void
+    {
+        $controller = new RoleController(Mockery::mock(EventRepo::class));
+        $role = new \App\Models\Role();
+        $role->name = 'Sample Talent';
+
+        $user = (object) [
+            'name' => 'Existing Name',
+            'first_name' => 'Existing First',
+            'last_name' => 'Existing Last',
+            'email' => 'existing@example.test',
+        ];
+
+        $userData = [
+            'first_name' => 'New First',
+            'last_name' => 'New Last',
+            'email' => 'new@example.test',
+        ];
+
+        $this->invokeEnsureUserIdentity($controller, $user, $userData, $role);
+
+        $this->assertSame('Existing Name', $user->name);
+        $this->assertSame('Existing First', $user->first_name);
+        $this->assertSame('Existing Last', $user->last_name);
+        $this->assertSame('existing@example.test', $user->email);
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -69,5 +117,13 @@ class RoleControllerUserNormalizationTest extends TestCase
         $method->setAccessible(true);
 
         return $method->invoke($controller, $user);
+    }
+
+    private function invokeEnsureUserIdentity(RoleController $controller, $user, array $userData, \App\Models\Role $role): void
+    {
+        $method = new \ReflectionMethod($controller, 'ensureUserIdentityAttributes');
+        $method->setAccessible(true);
+
+        $method->invoke($controller, $user, $userData, $role);
     }
 }


### PR DESCRIPTION
## Summary
- ensure talent role creation backfills missing identity fields on non-model authenticated users
- add helpers that safely assign normalized identity details to avoid undefined property errors
- centralize log level normalization with validation and dedicated unit tests to prevent invalid level configuration

## Testing
- php -l app/Support/Logging/LogLevelNormalizer.php
- php -l app/Http/Controllers/RoleController.php
- php -l tests/Unit/RoleControllerUserNormalizationTest.php
- php -l tests/Unit/LogLevelNormalizerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f30afd9500832eb2c8fc9263cdf804