### PR TITLE
Harden role creation views against malformed group data

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -868,10 +868,15 @@ class RoleController extends Controller
             $this->ensureUserIdentityAttributes($user, $userData, $role);
         }
 
+        $groupsForView = GroupPayloadNormalizer::forView(
+            session()->getOldInput('groups', [])
+        );
+
         $data = [
             'role' => $role,
             'user' => $user,
             'title' => __('messages.new_' . $role->type),
+            'groupsForView' => $groupsForView,
         ];
 
         if (function_exists('is_browser_testing') && is_browser_testing()) {
@@ -1095,10 +1100,17 @@ class RoleController extends Controller
 
         $role = Role::with('groups')->subdomain($subdomain)->firstOrFail();
 
+        $groupsInput = session()->getOldInput('groups');
+
+        if ($groupsInput === null) {
+            $groupsInput = $role->groups ?? [];
+        }
+
         $data = [
             'user' => auth()->user(),
             'role' => $role,
             'title' => __('messages.edit_' . $role->type),
+            'groupsForView' => GroupPayloadNormalizer::forView($groupsInput),
         ];
 
         if (function_exists('is_browser_testing') && is_browser_testing()) {

--- a/resources/views/layouts/app-admin.blade.php
+++ b/resources/views/layouts/app-admin.blade.php
@@ -150,9 +150,15 @@
                         <div class="sm:flex sm:items-center sm:ms-6">
                             <x-dropdown align="right" width="48">
                                 <x-slot name="trigger">
+                                    @php
+                                        $authenticatedUser = Auth::user();
+                                        $userName = trim((string) data_get($authenticatedUser, 'name', ''));
+                                        $userEmail = trim((string) data_get($authenticatedUser, 'email', ''));
+                                        $displayName = $userName !== '' ? $userName : $userEmail;
+                                    @endphp
                                     <button
                                         class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                                        <div>{{ Auth::user()->name }}</div>
+                                        <div>{{ $displayName }}</div>
 
                                         <div class="ms-1">
                                             <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg"

--- a/resources/views/role/edit.blade.php
+++ b/resources/views/role/edit.blade.php
@@ -1116,25 +1116,42 @@
 
                         <div class="mb-6">
                             <div id="groups-list">
-                                @php
-                                    $normalizedGroups = \App\Support\GroupPayloadNormalizer::forView(
-                                        old('groups', $role->groups ?? [])
-                                    );
-                                @endphp
-                                <div id="group-items">
-                                    @foreach($normalizedGroups as $i => $group)
-                                        @php
-                                            $groupKey = $group['id'] === '' ? $i : $group['id'];
-                                            $groupName = $group['name'];
-                                            $groupNameEn = $group['name_en'];
-                                            $groupSlug = $group['slug'];
-                                        @endphp
-                                        <div class="mb-4 p-4 border border-gray-200 dark:border-gray-700 rounded-lg">
-                                            <div class="mb-4">
-                                                <x-input-label for="group_name_{{ $groupKey }}" :value="__('messages.name')" />
-                                                <x-text-input name="groups[{{ $groupKey }}][name]" type="text" class="mt-1 block w-full" :value="$groupName" />
-                                            </div>
-                                            @if($role->language_code !== 'en' || auth()->user()->language_code !== 'en')
+                                  @php
+                                      $groupSource = isset($groupsForView)
+                                          ? $groupsForView
+                                          : \App\Support\GroupPayloadNormalizer::forView(
+                                              old('groups', $role->groups ?? [])
+                                          );
+
+                                      $normalizedGroups = is_iterable($groupSource)
+                                          ? $groupSource
+                                          : [];
+
+                                      $authenticatedLanguage = (string) data_get(auth()->user(), 'language_code', '');
+                                  @endphp
+                                  <div id="group-items">
+                                      @foreach($normalizedGroups as $i => $group)
+                                          @php
+                                              $groupId = (string) data_get($group, 'id', '');
+                                              $fallbackIndex = is_scalar($i) ? (string) $i : (string) ($loop->index ?? $i);
+
+                                              if ($fallbackIndex === '') {
+                                                  $fallbackIndex = isset($loop)
+                                                      ? 'group_' . $loop->index
+                                                      : 'group_' . uniqid('', false);
+                                              }
+
+                                              $groupKey = $groupId !== '' ? $groupId : $fallbackIndex;
+                                              $groupName = (string) data_get($group, 'name', '');
+                                              $groupNameEn = (string) data_get($group, 'name_en', '');
+                                              $groupSlug = (string) data_get($group, 'slug', '');
+                                          @endphp
+                                          <div class="mb-4 p-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+                                              <div class="mb-4">
+                                                  <x-input-label for="group_name_{{ $groupKey }}" :value="__('messages.name')" />
+                                                  <x-text-input name="groups[{{ $groupKey }}][name]" type="text" class="mt-1 block w-full" :value="$groupName" />
+                                              </div>
+                                              @if($role->language_code !== 'en' || $authenticatedLanguage !== 'en')
                                             <div class="mb-4">
                                                 <x-input-label for="group_name_en_{{ $groupKey }}" :value="__('messages.english_name')" />
                                                 <x-text-input name="groups[{{ $groupKey }}][name_en]" type="text" class="mt-1 block w-full" :value="$groupNameEn" />
@@ -1426,7 +1443,7 @@ function addGroupField() {
             <label for="group_name_new_${idx}" class="block font-medium text-sm text-gray-700 dark:text-gray-300">{{ __('messages.name') }}</label>
             <input name="groups[new_${idx}][name]" type="text" id="group_name_new_${idx}" class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm" />
         </div>
-        @if($role->language_code !== 'en' || auth()->user()->language_code !== 'en')
+          @if($role->language_code !== 'en' || $authenticatedLanguage !== 'en')
         <div class="mb-4">
             <label for="group_name_en_new_${idx}" class="block font-medium text-sm text-gray-700 dark:text-gray-300">{{ __('messages.english_name') }}</label>
             <input name="groups[new_${idx}][name_en]" type="text" id="group_name_en_new_${idx}" class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm" />

--- a/resources/views/testing/role/partials/form-fields.blade.php
+++ b/resources/views/testing/role/partials/form-fields.blade.php
@@ -139,17 +139,34 @@
             {{ __('messages.subschedules') }}
         </h2>
 
-        @php
-            $normalizedGroups = \App\Support\GroupPayloadNormalizer::forView(
-                old('groups', $role->groups ?? [])
-            );
-        @endphp
+          @php
+              $groupSource = isset($groupsForView)
+                  ? $groupsForView
+                  : \App\Support\GroupPayloadNormalizer::forView(
+                      old('groups', $role->groups ?? [])
+                  );
+
+              $normalizedGroups = is_iterable($groupSource)
+                  ? $groupSource
+                  : [];
+          @endphp
 
         <div id="group-items" class="space-y-4">
             @foreach($normalizedGroups as $index => $group)
-                @php
-                    $groupKey = $group['id'] === '' ? 'existing_' . $index : $group['id'];
-                @endphp
+                  @php
+                      $groupId = (string) data_get($group, 'id', '');
+                      $indexKey = is_scalar($index) ? (string) $index : (string) ($loop->index ?? $index);
+
+                      if ($indexKey === '') {
+                          $indexKey = isset($loop)
+                              ? 'group_' . $loop->index
+                              : 'group_' . uniqid('', false);
+                      }
+
+                        $groupKey = $groupId !== '' ? $groupId : 'existing_' . $indexKey;
+                        $groupName = (string) data_get($group, 'name', '');
+                        $groupSlug = (string) data_get($group, 'slug', '');
+                  @endphp
 
                 <div class="space-y-3 rounded-md border border-gray-200 p-4 dark:border-gray-700" data-group-item>
                     <div>
@@ -160,13 +177,13 @@
                             id="group_name_{{ $groupKey }}"
                             name="groups[{{ $groupKey }}][name]"
                             type="text"
-                            value="{{ $group['name'] }}"
+                              value="{{ $groupName }}"
                             class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                         >
                     </div>
 
-                    @if(!empty($group['slug']))
-                        <input type="hidden" name="groups[{{ $groupKey }}][slug]" value="{{ $group['slug'] }}">
+                      @if($groupSlug !== '')
+                          <input type="hidden" name="groups[{{ $groupKey }}][slug]" value="{{ $groupSlug }}">
                     @endif
 
                     <div class="flex justify-end">


### PR DESCRIPTION
## Summary
- normalize any previous `groups` input before rendering the create and edit role forms (including browser-testing variants)
- render group rows with `data_get`-based accessors and resilient keys so decoded `stdClass` payloads no longer trigger notices
- guard the admin layout display name by falling back to the user email when the `name` attribute is absent

## Testing
- `./vendor/bin/phpunit tests/Unit/GroupPayloadNormalizerTest.php` *(fails: vendor binaries not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f31028d660832e9e600c93ac84de5c