### PR TITLE
Fix role creation when authenticated user lacks name property

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -864,9 +864,9 @@ class RoleController extends Controller
             }
 
             $role->name = is_string($name) ? trim($name) : '';
-
-            $this->ensureUserIdentityAttributes($user, $userData, $role);
         }
+
+        $this->ensureUserIdentityAttributes($user, $userData, $role);
 
         $groupsForView = $this->prepareGroupsForView(
             session()->getOldInput('groups', [])
@@ -877,6 +877,7 @@ class RoleController extends Controller
             'user' => $user,
             'title' => __('messages.new_' . $role->type),
             'groupsForView' => $groupsForView,
+            'userData' => $userData,
         ];
 
         if (function_exists('is_browser_testing') && is_browser_testing()) {
@@ -1100,6 +1101,10 @@ class RoleController extends Controller
 
         $role = Role::with('groups')->subdomain($subdomain)->firstOrFail();
 
+        $user = auth()->user();
+        $userData = $this->normalizeAuthenticatedUser($user);
+        $this->ensureUserIdentityAttributes($user, $userData, $role);
+
         $groupsInput = session()->getOldInput('groups');
 
         if ($groupsInput === null) {
@@ -1107,10 +1112,11 @@ class RoleController extends Controller
         }
 
         $data = [
-            'user' => auth()->user(),
+            'user' => $user,
             'role' => $role,
             'title' => __('messages.edit_' . $role->type),
             'groupsForView' => $this->prepareGroupsForView($groupsInput),
+            'userData' => $userData,
         ];
 
         if (function_exists('is_browser_testing') && is_browser_testing()) {

--- a/resources/views/role/edit.blade.php
+++ b/resources/views/role/edit.blade.php
@@ -659,7 +659,7 @@
                         <div class="mb-3">
                             <x-input-label for="email" :value="__('messages.email') . ' *'" />
                             <x-text-input id="email" name="email" type="email" class="mt-1 block w-full"
-                                :value="old('email', $role->exists ? $role->email : $user->email)" required />
+                                :value="old('email', $role->exists ? $role->email : data_get($userData ?? [], 'email'))" required />
                             <x-input-error class="mt-2" :messages="$errors->get('email')" />
                         </div>
 

--- a/resources/views/testing/role/create.blade.php
+++ b/resources/views/testing/role/create.blade.php
@@ -15,6 +15,7 @@
                         'mode' => 'create',
                         'role' => $role,
                         'user' => $user,
+                        'userData' => $userData ?? [],
                     ])
                 </form>
             </div>

--- a/resources/views/testing/role/edit.blade.php
+++ b/resources/views/testing/role/edit.blade.php
@@ -16,6 +16,7 @@
                         'mode' => 'edit',
                         'role' => $role,
                         'user' => $user,
+                        'userData' => $userData ?? [],
                     ])
                 </form>
             </div>

--- a/resources/views/testing/role/partials/form-fields.blade.php
+++ b/resources/views/testing/role/partials/form-fields.blade.php
@@ -1,5 +1,8 @@
 @php
-    $emailValue = old('email', optional($user)->email ?? $role->email);
+    $normalizedUserData = is_array($userData ?? null) ? $userData : [];
+    $userEmail = data_get($normalizedUserData, 'email');
+    $userEmail = is_string($userEmail) ? trim($userEmail) : null;
+    $emailValue = old('email', $role->email ?? $userEmail);
     $acceptRequests = (int) old('accept_requests', $role->accept_requests ?? 0);
 @endphp
 


### PR DESCRIPTION
## Summary
- ensure the RoleController always normalizes authenticated user attributes and shares the resulting data with role views
- update the role edit and testing views to read contact email values from normalized user data instead of direct property access

## Testing
- php artisan test --testsuite=Unit --filter=RoleControllerUserNormalizationTest *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f43c9bf030832ea12b42f8417a9e86