### PR TITLE
Log group diagnostics before role initialization

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -833,6 +833,14 @@ class RoleController extends Controller
             return redirect()->back()->with('error', __('messages.not_authorized'));
         }
 
+        $rawGroupInput = session()->getOldInput('groups', []);
+
+        $this->logGroupPayloadDiagnostics($rawGroupInput, 'role.create.old_input');
+
+        $groupsForView = $this->prepareGroupsForView($rawGroupInput);
+
+        $this->logGroupPayloadDiagnostics($groupsForView, 'role.create.groups_for_view');
+
         $role = new Role;
         $role->type = $type;
         $role->font_family = 'Roboto';
@@ -868,14 +876,6 @@ class RoleController extends Controller
         }
 
         $this->ensureUserIdentityAttributes($user, $userData, $role);
-
-        $rawGroupInput = session()->getOldInput('groups', []);
-
-        $this->logGroupPayloadDiagnostics($rawGroupInput, 'role.create.old_input');
-
-        $groupsForView = $this->prepareGroupsForView($rawGroupInput);
-
-        $this->logGroupPayloadDiagnostics($groupsForView, 'role.create.groups_for_view');
 
         $data = [
             'role' => $role,


### PR DESCRIPTION
## Summary
- move the session group payload retrieval to the top of `RoleController::create`
- ensure diagnostics for the raw and normalized group data run even if later initialization fails

## Testing
- ⚠️ `composer install --no-interaction` *(fails: CONNECT tunnel failed responses 403 from github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68f45adf61f4832eaa5676f1fc369418