### PR TITLE
Handle gradient assets without explicit names

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2442,6 +2442,12 @@ class RoleController extends Controller
             }
         }
 
+        $colors = $this->extractColors($entry);
+
+        if (! empty($colors)) {
+            return implode(' → ', $colors);
+        }
+
         return null;
     }
 
@@ -3034,7 +3040,7 @@ class RoleController extends Controller
         }
 
         if (is_array($item)) {
-            foreach (['name', 'value', 'label', 'title'] as $key) {
+            foreach (['name', 'value', 'label', 'title', 'id', 'slug'] as $key) {
                 if (array_key_exists($key, $item)) {
                     $candidate = $this->determineRoleAssetName($item[$key], $original, $depth + 1);
 
@@ -3050,6 +3056,12 @@ class RoleController extends Controller
                 if (is_string($candidate) && trim($candidate) !== '') {
                     return $candidate;
                 }
+            }
+
+            $colors = $this->extractColors($item, $original, $depth + 1);
+
+            if (! empty($colors)) {
+                return implode(' → ', $colors);
             }
 
             return null;
@@ -3123,6 +3135,12 @@ class RoleController extends Controller
                 if (is_string($candidate) && trim($candidate) !== '') {
                     return $candidate;
                 }
+            }
+
+            $colors = $this->extractColors($item, $original, $depth + 1);
+
+            if (! empty($colors)) {
+                return implode(' → ', $colors);
             }
         }
 

--- a/app/Utils/ColorUtils.php
+++ b/app/Utils/ColorUtils.php
@@ -221,6 +221,12 @@ class ColorUtils
                     return $candidate;
                 }
             }
+
+            $colors = self::extractColors($item, $depth + 1);
+
+            if (! empty($colors)) {
+                return implode(' → ', $colors);
+            }
         }
 
         return null;
@@ -285,6 +291,12 @@ class ColorUtils
                 if (is_string($candidate) && trim($candidate) !== '') {
                     return $candidate;
                 }
+            }
+
+            $colors = self::extractColors($item, $depth + 1);
+
+            if (! empty($colors)) {
+                return implode(' → ', $colors);
             }
         }
 


### PR DESCRIPTION
## Summary
- fall back to joining extracted color stops when role asset entries do not include a name or label
- reuse the same fallback logic inside ColorUtils so random defaults continue to work with color-only gradients

## Testing
- php -l app/Http/Controllers/RoleController.php
- php -l app/Utils/ColorUtils.php

------
https://chatgpt.com/codex/tasks/task_e_68f57bc6d848832e8685185c39d321ab