### PR TITLE
Add dedicated logging for role user normalization

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -116,6 +116,13 @@ return [
             'replace_placeholders' => true,
         ],
 
+        'role_debug' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/role_debug.log'),
+            'level' => $normalizeLogLevel('debug'),
+            'replace_placeholders' => true,
+        ],
+
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),


### PR DESCRIPTION
## Summary
- add a dedicated `role_debug` logging channel that writes to `storage/logs/role_debug.log`
- capture detailed diagnostics for normalizeAuthenticatedUser input and output while masking sensitive data
- add reusable helpers to safely serialize values for debug logging

## Testing
- php -l app/Http/Controllers/RoleController.php

------
https://chatgpt.com/codex/tasks/task_e_68f59e3562e0832eb8d9c89370ace5b4