### PR TITLE
Fix font option rendering in role edit view

### DIFF
--- a/resources/views/role/edit.blade.php
+++ b/resources/views/role/edit.blade.php
@@ -800,9 +800,9 @@
                                 <select id="font_family" name="font_family" onchange="onChangeFont()"
                                     class="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">
                                     @foreach($fonts as $font)
-                                    <option value="{{ $font->value }}"
-                                        {{ $role->font_family == $font->value ? 'SELECTED' : '' }}>
-                                        {{ $font->label }}</option>
+                                    <option value="{{ $font['value'] }}"
+                                        {{ $role->font_family == $font['value'] ? 'SELECTED' : '' }}>
+                                        {{ $font['label'] }}</option>
                                     @endforeach
                                 </select>
                                 <x-input-error class="mt-2" :messages="$errors->get('font_family')" />


### PR DESCRIPTION
## Summary
- update the role edit view to read font option data from arrays instead of objects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f628ddd034832e93542bed754bb6f5