### PR TITLE
Fix guest layout CSS causing Blade parse error

### DIFF
--- a/resources/views/layouts/app-guest.blade.php
+++ b/resources/views/layouts/app-guest.blade.php
@@ -92,12 +92,7 @@
         }
 
         body {
-            @media (prefers-color-scheme: dark) {
-                color: #33383C !important;
-            }
-            @media (prefers-color-scheme: light) {
-                color: #33383C !important;
-            }
+            color: #33383C !important;
             font-family: '{{ isset($otherRole) && $otherRole ? $otherRole->font_family : $role->font_family }}', sans-serif !important;
             min-height: 100vh;
             background-attachment: scroll;


### PR DESCRIPTION
## Summary
- remove Blade-misinterpreted `@media` blocks from the guest layout stylesheet
- apply the intended text color directly to the body element to avoid runtime parse errors

## Testing
- not run (environment-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f6a151c2fc832eb93566d05e5c0626