### PR TITLE
Handle missing event data in claim emails

### DIFF
--- a/app/Mail/ClaimRole.php
+++ b/app/Mail/ClaimRole.php
@@ -71,7 +71,11 @@ class ClaimRole extends Mailable
 
     public function headers(): Headers
     {
-        $role = $this->event->role();
+        $role = $this->event?->role();
+
+        if (! $role) {
+            return new Headers();
+        }
 
         return new Headers(
             text: [
@@ -84,24 +88,24 @@ class ClaimRole extends Mailable
     protected function templateData(): array
     {
         $event = $this->event;
-        $role = $event->role();
-        $user = $event->user;
-        $curator = $event->curator();
+        $role = $event?->role();
+        $user = $event?->user;
+        $curator = $event?->curator();
 
-        $roleEmail = $role->email;
+        $roleEmail = $role?->email;
         $encodedEmail = $roleEmail ? base64_encode($roleEmail) : null;
 
         $defaultEmail = config('mail.from.address') ?? config('mail.mailers.smtp.username') ?? 'no-reply@example.com';
         $defaultName = config('mail.from.name') ?? config('app.name');
 
         return [
-            'event_name' => $event->name,
-            'role_name' => $role->name,
-            'venue_name' => $event->getVenueDisplayName(),
-            'curator_name' => $curator ? $curator->name : '',
-            'organizer_name' => $user ? $user->name : $defaultName,
-            'organizer_email' => $user ? $user->email : $defaultEmail,
-            'event_url' => $event->getGuestUrl(),
+            'event_name' => $event?->name ?? '',
+            'role_name' => $role?->name ?? '',
+            'venue_name' => $event?->getVenueDisplayName() ?? '',
+            'curator_name' => $curator?->name ?? '',
+            'organizer_name' => $user?->name ?? $defaultName,
+            'organizer_email' => $user?->email ?? $defaultEmail,
+            'event_url' => $event?->getGuestUrl() ?? '',
             'sign_up_url' => $encodedEmail ? route('sign_up', ['email' => $encodedEmail]) : route('sign_up'),
             'unsubscribe_url' => $encodedEmail
                 ? route('role.show_unsubscribe', ['email' => $encodedEmail])

--- a/app/Mail/ClaimVenue.php
+++ b/app/Mail/ClaimVenue.php
@@ -71,7 +71,11 @@ class ClaimVenue extends Mailable
 
     public function headers(): Headers
     {
-        $role = $this->event->role();
+        $role = $this->event?->role();
+
+        if (! $role) {
+            return new Headers();
+        }
 
         return new Headers(
             text: [
@@ -84,25 +88,25 @@ class ClaimVenue extends Mailable
     protected function templateData(): array
     {
         $event = $this->event;
-        $role = $event->role();
-        $venue = $event->venue;
-        $user = $event->user;
-        $curator = $event->curator();
+        $role = $event?->role();
+        $venue = $event?->venue;
+        $user = $event?->user;
+        $curator = $event?->curator();
 
-        $venueEmail = $venue->email;
+        $venueEmail = $venue?->email;
         $encodedEmail = $venueEmail ? base64_encode($venueEmail) : null;
 
         $defaultEmail = config('mail.from.address') ?? config('mail.mailers.smtp.username') ?? 'no-reply@example.com';
         $defaultName = config('mail.from.name') ?? config('app.name');
 
         return [
-            'event_name' => $event->name,
-            'role_name' => $role->name,
-            'venue_name' => $venue->name,
-            'curator_name' => $curator ? $curator->name : '',
-            'organizer_name' => $user ? $user->name : $defaultName,
-            'organizer_email' => $user ? $user->email : $defaultEmail,
-            'event_url' => $event->getGuestUrl(),
+            'event_name' => $event?->name ?? '',
+            'role_name' => $role?->name ?? '',
+            'venue_name' => $venue?->name ?? '',
+            'curator_name' => $curator?->name ?? '',
+            'organizer_name' => $user?->name ?? $defaultName,
+            'organizer_email' => $user?->email ?? $defaultEmail,
+            'event_url' => $event?->getGuestUrl() ?? '',
             'sign_up_url' => $encodedEmail ? route('sign_up', ['email' => $encodedEmail]) : route('sign_up'),
             'unsubscribe_url' => $encodedEmail
                 ? route('role.show_unsubscribe', ['email' => $encodedEmail])

--- a/resources/views/mail/role/claim.blade.php
+++ b/resources/views/mail/role/claim.blade.php
@@ -3,9 +3,13 @@
 
 {{ $subject }}
 
-<x-mail::button :url="$event->getGuestUrl()">
+@php($eventUrl = $event?->getGuestUrl())
+
+@if ($eventUrl)
+<x-mail::button :url="$eventUrl">
 {{ __('messages.view_event') }}
 </x-mail::button>
+@endif
 
 {{ __('messages.claim_email_line1') }}
 

--- a/resources/views/mail/venue/claim.blade.php
+++ b/resources/views/mail/venue/claim.blade.php
@@ -3,9 +3,13 @@
 
 {{ $subject }}
 
-<x-mail::button :url="$event->getGuestUrl()">
+@php($eventUrl = $event?->getGuestUrl())
+
+@if ($eventUrl)
+<x-mail::button :url="$eventUrl">
 {{ __('messages.view_event') }}
 </x-mail::button>
+@endif
 
 {{ __('messages.claim_email_line1') }}
 


### PR DESCRIPTION
## Summary
- guard the claim role and venue mail templates from calling getGuestUrl() on a null event
- ensure claim mail template data tolerates missing relationships before building URLs or headers

## Testing
- not run (dependencies unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f6fb5d0eb0832eaa3fd1b05583aca3