### PR TITLE
Guard admin schedule view against missing talent role

### DIFF
--- a/resources/views/role/show-admin-schedule.blade.php
+++ b/resources/views/role/show-admin-schedule.blade.php
@@ -9,18 +9,19 @@
     </header>
     <ul role="list" class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 pt-5">
         @foreach($unscheduled as $event)
-        @if(! $event->starts_at)
+        @php($talentRole = $event->role())
+        @if(! $event->starts_at && $talentRole)
         <li class="col-span-1 flex flex-col divide-y divide-gray-200 rounded-lg bg-white text-center shadow">
-            <a href="{{ $event->role()->getGuestUrl() }}" target="_blank">
+            <a href="{{ $talentRole->getGuestUrl() }}" target="_blank">
                 <div class="flex flex-1 flex-col p-8">
-                    @if ($event->role()->profile_image_url)
+                    @if ($talentRole->profile_image_url)
                     <img class="mx-auto rounded-lg h-32 w-32 flex-shrink-0 object-cover"
-                        src="{{ $event->role()->profile_image_url }}"
+                        src="{{ $talentRole->profile_image_url }}"
                         alt="Profile Image">
                     @endif
-                    <h3 class="mt-6 text-sm font-medium text-gray-900">{{ $event->role()->name }}</h3>
+                    <h3 class="mt-6 text-sm font-medium text-gray-900">{{ $talentRole->name }}</h3>
                     <dl class="mt-1 flex flex-grow flex-col justify-between">
-                        <dd class="text-sm text-gray-500 line-clamp-3">{{ $event->role()->description }}</dd>
+                        <dd class="text-sm text-gray-500 line-clamp-3">{{ $talentRole->description }}</dd>
                     </dl>
                 </div>
             </a>


### PR DESCRIPTION
## Summary
- guard the admin schedule unscheduled list against events without a linked talent role
- reuse the retrieved role object when rendering links and details to avoid null access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7022326a0832e932ed13ce96c05a2