### PR TITLE
Fix Blade event handlers using x-on syntax

### DIFF
--- a/resources/views/components/dropdown.blade.php
+++ b/resources/views/components/dropdown.blade.php
@@ -13,8 +13,8 @@ $width = match ($width) {
 };
 @endphp
 
-<div class="relative" x-data="{ open: false }" @click.outside="open = false" @close.stop="open = false">
-    <div @click="open = ! open">
+<div class="relative" x-data="{ open: false }" x-on:click.outside="open = false" x-on:close.stop="open = false">
+    <div x-on:click="open = ! open">
         {{ $trigger }}
     </div>
 
@@ -27,7 +27,7 @@ $width = match ($width) {
             x-transition:leave-end="opacity-0 scale-95"
             class="absolute z-50 mt-2 {{ $width }} rounded-md shadow-lg {{ $alignmentClasses }}"
             style="display: none;"
-            @click="open = false">
+            x-on:click="open = false">
         <div class="rounded-md ring-1 ring-black ring-opacity-5 {{ $contentClasses }}">
             {{ $content }}
         </div>

--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -194,7 +194,7 @@
   </h2>
 
   <form method="POST"
-        @submit="validateForm"
+        x-on:submit="validateForm"
         action="{{ $event->exists ? route('event.update', ['subdomain' => $subdomain, 'hash' => \App\Utils\UrlUtils::encodeId($event->id)]) : route('event.store', ['subdomain' => $subdomain]) }}"
         enctype="multipart/form-data">
 
@@ -226,7 +226,7 @@
                                     <div class="flex items-center">
                                         <input id="in_person" name="event_type" type="checkbox" v-model="isInPerson"
                                             class="h-4 w-4 text-[#4E81FA] focus:ring-[#4E81FA] border-gray-300 rounded"
-                                            @change="ensureOneChecked('in_person')">
+                                            x-on:change="ensureOneChecked('in_person')">
                                         <label for="in_person" class="ml-3 block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
                                             {{ __('messages.in_person') }}
                                         </label>
@@ -234,7 +234,7 @@
                                     <div class="flex items-center pl-3">
                                         <input id="online" name="event_type" type="checkbox" v-model="isOnline"
                                             class="h-4 w-4 text-[#4E81FA] focus:ring-[#4E81FA] border-gray-300 rounded"
-                                            @change="ensureOneChecked('online')">
+                                            x-on:change="ensureOneChecked('online')">
                                         <label for="online" class="ml-3 block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
                                             {{ __('messages.online') }}
                                         </label>
@@ -296,7 +296,7 @@
                                         <x-input-label for="venue_email" :value="__('messages.email')" />
                                         <div class="flex mt-1">
                                             <x-text-input id="venue_email" name="venue_email" type="email" class="block w-full"
-                                                @blur="searchVenues" v-model="venueEmail" autocomplete="off" />
+                                                x-on:blur="searchVenues" v-model="venueEmail" autocomplete="off" />
                                         </div>
                                         @if (config('app.hosted'))
                                         <p class="mt-2 text-sm text-gray-500">
@@ -315,7 +315,7 @@
                                                         @{{ venue.address1 }}
                                                     </span>
                                                 </div>
-                                                <x-primary-button @click="selectVenue(venue)" type="button">
+                                                <x-primary-button x-on:click="selectVenue(venue)" type="button">
                                                     {{ __('messages.select') }}
                                                 </x-primary-button>
                                             </div>
@@ -366,7 +366,7 @@
                                             <x-secondary-button id="validate_button" onclick="onValidateClick()">{{ __('messages.validate_address') }}</x-secondary-button>
                                             <x-secondary-button id="accept_button" onclick="acceptAddress(event)" class="hidden">{{ __('messages.accept') }}</x-secondary-button>
                                             @endif
-                                            <x-primary-button v-if="showVenueAddressFields" type="button" @click="updateSelectedVenue()">{{ __('messages.done') }}</x-primary-button>
+                                            <x-primary-button v-if="showVenueAddressFields" type="button" x-on:click="updateSelectedVenue()">{{ __('messages.done') }}</x-primary-button>
                                         </div>
                                     </div>
 
@@ -392,10 +392,10 @@
                                         </span>
                                     </div>
                                     <div>
-                                        <x-secondary-button v-if="!selectedVenue.user_id" @click="editSelectedVenue" type="button" class="mr-2">
+                                        <x-secondary-button v-if="!selectedVenue.user_id" x-on:click="editSelectedVenue" type="button" class="mr-2">
                                             {{ __('messages.edit') }}
                                         </x-secondary-button>
-                                        <x-secondary-button @click="clearSelectedVenue" type="button">
+                                        <x-secondary-button x-on:click="clearSelectedVenue" type="button">
                                             {{ __('messages.remove') }}
                                         </x-secondary-button>
                                     </div>
@@ -432,8 +432,8 @@
                                                 <x-text-input v-bind:id="'edit_member_name_' + member.id" 
                                                     v-bind:name="'members[' + member.id + '][name]'" type="text" class="mr-2 block w-full"
                                                     v-model="selectedMembers.find(m => m.id === member.id).name" required autofocus
-                                                    @keydown.enter.prevent="editMember()" autocomplete="off" />
-                                                <x-primary-button @click="editMember()" type="button">
+                                                    x-on:keydown.enter.prevent="editMember()" autocomplete="off" />
+                                                <x-primary-button x-on:click="editMember()" type="button">
                                                     {{ __('messages.done') }}
                                                 </x-primary-button>
                                             </div>
@@ -444,14 +444,14 @@
                                             <x-input-label for="edit_member_email" :value="__('messages.email')" />
                                             <x-text-input v-bind:id="'edit_member_email_' + member.id" 
                                                 v-bind:name="'members[' + member.id + '][email]'" type="email" class="mr-2 block w-full" 
-                                                v-model="selectedMembers.find(m => m.id === member.id).email" @keydown.enter.prevent="editMember()" autocomplete="off" />
+                                                v-model="selectedMembers.find(m => m.id === member.id).email" x-on:keydown.enter.prevent="editMember()" autocomplete="off" />
                                         </div>
 
                                         <div class="mb-6">
                                             <x-input-label for="edit_member_youtube_url" :value="__('messages.youtube_video_url')" />
                                             <x-text-input v-bind:id="'edit_member_youtube_url_' + member.id" 
                                                 v-bind:name="'members[' + member.id + '][youtube_url]'" type="url" class="mr-2 block w-full" 
-                                                v-model="selectedMembers.find(m => m.id === member.id).youtube_url" @keydown.enter.prevent="editMember()" autocomplete="off" />
+                                                v-model="selectedMembers.find(m => m.id === member.id).youtube_url" x-on:keydown.enter.prevent="editMember()" autocomplete="off" />
                                         </div>
 
                                     </div>
@@ -475,10 +475,10 @@
                                             </a>
                                         </div>
                                         <div>
-                                            <x-secondary-button v-if="!member.user_id" @click="editMember(member)" type="button" class="mr-2">
+                                            <x-secondary-button v-if="!member.user_id" x-on:click="editMember(member)" type="button" class="mr-2">
                                                 {{ __('messages.edit') }}
                                             </x-secondary-button>
-                                            <x-secondary-button @click="removeMember(member)" type="button">
+                                            <x-secondary-button x-on:click="removeMember(member)" type="button">
                                                 {{ __('messages.remove') }}
                                             </x-secondary-button>
                                         </div>
@@ -511,7 +511,7 @@
                                 </fieldset>
 
                                 <div v-if="memberType === 'use_existing' && Object.keys(members).length > 0">
-                                    <select v-model="selectedMember" @change="addExistingMember" id="selected_member"
+                                    <select v-model="selectedMember" x-on:change="addExistingMember" id="selected_member"
                                         class="border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm">
                                         <option value="" disabled selected>{{ __('messages.please_select') }}</option>
                                         <option v-for="member in filteredMembers" :key="member.id" :value="member">
@@ -524,9 +524,9 @@
                                     <div class="mb-6">
                                         <x-input-label for="member_name" :value="__('messages.name') . ' *'" />
                                         <div class="flex mt-1">
-                                            <x-text-input id="member_name" @keydown.enter.prevent="addMember"
+                                            <x-text-input id="member_name" x-on:keydown.enter.prevent="addMember"
                                                 v-model="memberName" type="text" class="mr-2 block w-full" required autocomplete="off" />
-                                            <x-primary-button @click="addMember" type="button">
+                                            <x-primary-button x-on:click="addMember" type="button">
                                                 {{ __('messages.add') }}
                                             </x-primary-button>
                                         </div>
@@ -536,7 +536,7 @@
                                         <x-input-label for="member_email" :value="__('messages.email')" />
                                         <div class="flex mt-1">
                                             <x-text-input id="member_email" name="member_email" type="email" class="mr-2 block w-full"
-                                            @keydown.enter.prevent="addMember" @blur="searchMembers" v-model="memberEmail" autocomplete="off" />
+                                            x-on:keydown.enter.prevent="addMember" x-on:blur="searchMembers" v-model="memberEmail" autocomplete="off" />
                                         </div>
                                         @if (config('app.hosted'))
                                         <p class="mt-2 text-sm text-gray-500">
@@ -562,7 +562,7 @@
                                                         </svg>
                                                     </a>
                                                 </div>
-                                                <x-primary-button @click="selectMember(member)" type="button">
+                                                <x-primary-button x-on:click="selectMember(member)" type="button">
                                                     {{ __('messages.select') }}
                                                 </x-primary-button>
                                             </div>
@@ -571,7 +571,7 @@
 
                                     <div class="mb-6">
                                         <x-input-label for="member_youtube_url" :value="__('messages.youtube_video_url')" />
-                                        <x-text-input id="member_youtube_url" @keydown.enter.prevent="addMember"
+                                        <x-text-input id="member_youtube_url" x-on:keydown.enter.prevent="addMember"
                                             v-model="memberYoutubeUrl" type="url" class="mr-2 block w-full" autocomplete="off" />
                                     </div>
                                 
@@ -580,7 +580,7 @@
                             </div>
 
                             <div v-if="!showMemberTypeRadio" class="mt-4 flex justify-end">
-                                <x-secondary-button @click="showAddMemberForm" type="button">
+                                <x-secondary-button x-on:click="showAddMemberForm" type="button">
                                     {{ __('messages.add') }}
                                 </x-secondary-button>
                             </div>
@@ -612,7 +612,7 @@
                                 class="mt-1 block w-full"
                                 maxlength="255"
                                 v-model="eventSlug"
-                                @input="onSlugInput"
+                                x-on:input="onSlugInput"
                                 autocomplete="off" />
                             <div class="mt-2 text-sm text-gray-500 dark:text-gray-400 flex items-center gap-2">
                                 <span class="truncate">
@@ -630,7 +630,7 @@
                                         @{{ eventSlug || slugPreviewPlaceholder }}
                                     </template>
                                 </span>
-                                <button v-if="canUseEventUrl" type="button" @click="copyEventUrl"
+                                <button v-if="canUseEventUrl" type="button" x-on:click="copyEventUrl"
                                     class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300"
                                     title="{{ __('messages.copy_url') }}">
                                     <template v-if="eventUrlCopied">
@@ -776,7 +776,7 @@
                                            value="{{ $curator->encodeId() }}"
                                            {{ (! $event->exists && ($role->subdomain == $curator->subdomain || session('pending_request') == $curator->subdomain || (isset($preselectedCurators) && in_array($curator->encodeId(), $preselectedCurators)))) || $event->curators->contains($curator->id) ? 'checked' : '' }}
                                            class="h-4 w-4 text-[#4E81FA] focus:ring-[#4E81FA] border-gray-300 rounded"
-                                           @change="toggleCuratorGroupSelection('{{ $curator->encodeId() }}')">
+                                           x-on:change="toggleCuratorGroupSelection('{{ $curator->encodeId() }}')">
                                     <label for="curator_{{ $curator->encodeId() }}" class="ml-2 block text-sm font-medium text-gray-900 dark:text-gray-100">
                                         {{ $curator->name }}
                                     </label>
@@ -933,7 +933,7 @@
                                                     class="mt-1 block w-full" required />
                                             </div>
                                             <div v-if="tickets.length > 1" class="flex items-end">
-                                                <x-secondary-button @click="removeTicket(index)" type="button" class="mt-1">
+                                                <x-secondary-button x-on:click="removeTicket(index)" type="button" class="mt-1">
                                                     {{ __('messages.remove') }}
                                                 </x-secondary-button>
                                             </div>
@@ -973,7 +973,7 @@
                                         </div>
                                     </div>
 
-                                    <x-secondary-button @click="addTicket" type="button" class="mt-4">
+                                    <x-secondary-button x-on:click="addTicket" type="button" class="mt-4">
                                         {{ __('messages.add_type') }}
                                     </x-secondary-button>
                                 </div>
@@ -992,7 +992,7 @@
                                             <input id="expire_unpaid_tickets_checkbox" name="expire_unpaid_tickets_checkbox" type="checkbox" 
                                                 v-model="showExpireUnpaid"
                                                 class="h-4 w-4 text-[#4E81FA] focus:ring-[#4E81FA] border-gray-300 rounded"
-                                                @change="toggleExpireUnpaid">
+                                                x-on:change="toggleExpireUnpaid">
                                             <label for="expire_unpaid_tickets_checkbox" class="ml-3 block text-sm font-medium leading-6 text-gray-900 dark:text-gray-100">
                                                 {{ __('messages.expire_unpaid_tickets') }}
                                             </label>

--- a/resources/views/event/import.blade.php
+++ b/resources/views/event/import.blade.php
@@ -41,14 +41,14 @@
                                     rows="7"
                                     v-model="eventDetails"
                                     v-bind:readonly="savedEvent"
-                                    @input="handleInputChange"
-                                    @paste="handlePaste" 
-                                    @keydown="handleKeydown"
-                                    @dragenter.prevent="dragEnterDetails"
-                                    @dragover.prevent="dragOverDetails"
-                                    @dragleave.prevent="dragLeaveDetails"
-                                    @drop.prevent="handleDetailsImageDrop"
-                                    @dragend="dragEndDetails"
+                                    x-on:input="handleInputChange"
+                                    x-on:paste="handlePaste"
+                                    x-on:keydown="handleKeydown"
+                                    x-on:dragenter.prevent="dragEnterDetails"
+                                    x-on:dragover.prevent="dragOverDetails"
+                                    x-on:dragleave.prevent="dragLeaveDetails"
+                                    x-on:drop.prevent="handleDetailsImageDrop"
+                                    x-on:dragend="dragEndDetails"
                                     autofocus {{ config('services.google.gemini_key') ? '' : 'disabled' }}
                                     :class="['mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] dark:focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:ring-[#4E81FA] rounded-md shadow-sm transition-all duration-200', 
                                         isDraggingDetails ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30 ring-2 ring-blue-200 dark:ring-blue-800' : '']"
@@ -57,12 +57,12 @@
                                     placeholder="{{ __('messages.drag_drop_image_or_type_text') }}"></textarea>
                                 
                                 <!-- Drop message overlay for textarea -->
-                                <div v-show="isDraggingDetails" 
-                                     @dragenter.prevent="dragEnterDetails"
-                                     @dragover.prevent="dragOverDetails"
-                                     @dragleave.prevent="dragLeaveDetails"
-                                     @drop.prevent="handleDetailsImageDrop"
-                                     @dragend="dragEndDetails"
+                                <div v-show="isDraggingDetails"
+                                     x-on:dragenter.prevent="dragEnterDetails"
+                                     x-on:dragover.prevent="dragOverDetails"
+                                     x-on:dragleave.prevent="dragLeaveDetails"
+                                     x-on:drop.prevent="handleDetailsImageDrop"
+                                     x-on:dragend="dragEndDetails"
                                      class="absolute inset-0 flex items-center justify-center bg-blue-50 dark:bg-blue-900/30 border-2 border-blue-500 rounded-md z-10 transition-all duration-200 ease-in-out"
                                      :class="{ 'opacity-100 scale-100': isDraggingDetails, 'opacity-0 scale-95': !isDraggingDetails }">
                                     <div class="text-center">
@@ -88,8 +88,8 @@
                                     </div>
                                     
                                     <!-- Remove image button -->
-                                    <button 
-                                        @click="removeDetailsImage"
+                                    <button
+                                        x-on:click="removeDetailsImage"
                                         type="button"
                                         :class="['absolute -top-1 w-5 h-5 bg-red-500 hover:bg-red-600 text-white rounded-full flex items-center justify-center text-xs transition-colors', 
                                             {{ is_rtl() ? "'-left-1'" : "'-right-1'" }}]"
@@ -101,9 +101,9 @@
                                 </div>
                                 
                                 <!-- Plus icon button for file picker -->
-                                <button 
+                                <button
                                     type="button"
-                                    @click="openDetailsFileSelector"
+                                    x-on:click="openDetailsFileSelector"
                                     :disabled="isLoading || detailsImage"
                                     :class="['absolute p-2 rounded-md transition-all duration-200 shadow-md', 
                                         {{ is_rtl() ? "'left-16'" : "'right-16'" }} + ' bottom-3',
@@ -117,9 +117,9 @@
                                 </button>
                                 
                                 <!-- Submit button with up arrow -->
-                                <button 
+                                <button
                                     type="button"
-                                    @click="handleSubmit"
+                                    x-on:click="handleSubmit"
                                     :disabled="!canSubmit || isLoading"
                                     :class="['absolute p-2 rounded-md transition-all duration-200 shadow-md', 
                                         {{ is_rtl() ? "'left-5'" : "'right-5'" }} + ' bottom-3',
@@ -184,10 +184,10 @@
             <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between">
                 @if (auth()->user() && auth()->user()->isAdmin())
                 <div class="flex items-center mb-3 sm:mb-0">
-                    <input type="checkbox" 
-                            id="show_all_fields" 
-                            v-model="showAllFields" 
-                            @change="saveShowAllFieldsPreference"
+                    <input type="checkbox"
+                            id="show_all_fields"
+                            v-model="showAllFields"
+                            x-on:change="saveShowAllFieldsPreference"
                             class="rounded border-gray-300 text-blue-500 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50">
                     <label for="show_all_fields" class="ml-2 text-sm text-gray-700 dark:text-gray-300">
                         {{ __('messages.show_all_fields') }}
@@ -199,7 +199,7 @@
 
                 <!-- Action buttons - now includes Save All -->
                 <div class="flex gap-2 self-end sm:self-auto">
-                    <button @click="handleSaveAll" v-if="({{ request()->has('automate') ? 'true' : 'false' }} || preview.parsed.length > 1) && !{{ isset($isGuest) && $isGuest ? 'true' : 'false' }}" type="button" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors">
+                    <button x-on:click="handleSaveAll" v-if="({{ request()->has('automate') ? 'true' : 'false' }} || preview.parsed.length > 1) && !{{ isset($isGuest) && $isGuest ? 'true' : 'false' }}" type="button" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors">
                         {{ __('messages.save_all') }}
                     </button>
                 </div>
@@ -209,10 +209,10 @@
 
         @if (auth()->user() && auth()->user()->isAdmin())
         <div class="flex items-center my-4">
-            <input type="checkbox" 
-                    id="show_all_fields" 
-                    v-model="showAllFields" 
-                    @change="saveShowAllFieldsPreference"
+            <input type="checkbox"
+                    id="show_all_fields"
+                    v-model="showAllFields"
+                    x-on:change="saveShowAllFieldsPreference"
                     class="rounded border-gray-300 text-blue-500 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-500 focus:ring-opacity-50">
             <label for="show_all_fields" class="ml-2 text-sm text-gray-700 dark:text-gray-300">
                 {{ __('messages.show_all_fields') }}
@@ -223,7 +223,7 @@
         <!-- Hidden file input for details image -->
         <input type="file"
                 ref="detailsFileInput"
-                @change="handleDetailsFileSelect"
+                x-on:change="handleDetailsFileSelect"
                 accept="image/*"
                 class="hidden">
 
@@ -272,8 +272,8 @@
                                         {{ __('messages.view') }}
                                     </a>
                                     <!-- Show Select button if event hasn't been added to curator schedule -->
-                                    <button v-if="isCurator && !preview.parsed[idx].is_curated" 
-                                            @click="handleSelect(idx)" 
+                                    <button v-if="isCurator && !preview.parsed[idx].is_curated"
+                                            x-on:click="handleSelect(idx)"
                                             type="button" 
                                             :disabled="savingEvents[idx]"
                                             :class="['px-4 py-2 rounded-md transition-colors', 
@@ -393,21 +393,21 @@
                         <!-- Add buttons at the bottom of the left column -->
                         <div class="mt-12 flex justify-end gap-2">
                             <template v-if="savedEvents[idx]">
-                                <button v-if="!savedEventData[idx]?.is_curated && !{{ isset($isGuest) && $isGuest ? 'true' : 'false' }}" @click="handleEdit(idx)" type="button" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors">
+                                <button v-if="!savedEventData[idx]?.is_curated && !{{ isset($isGuest) && $isGuest ? 'true' : 'false' }}" x-on:click="handleEdit(idx)" type="button" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors">
                                     {{ __('messages.edit') }}
                                 </button>
-                                <button v-if="{{ auth()->check() ? 'true' : 'false' }}" @click="handleView(idx)" type="button" class="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 transition-colors">
+                                <button v-if="{{ auth()->check() ? 'true' : 'false' }}" x-on:click="handleView(idx)" type="button" class="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 transition-colors">
                                     {{ __('messages.view') }}
                                 </button>
                             </template>
                             <template v-else>
-                                <button @click="handleRemoveEvent(idx)" v-if="preview.parsed.length > 1" type="button" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
+                                <button x-on:click="handleRemoveEvent(idx)" v-if="preview.parsed.length > 1" type="button" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
                                     {{ __('messages.remove') }}
                                 </button>
-                                <button @click="handleClear" type="button" v-if="preview.parsed.length == 1" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
+                                <button x-on:click="handleClear" type="button" v-if="preview.parsed.length == 1" class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors">
                                     {{ __('messages.clear') }}
                                 </button>
-                                <button @click="handleSave(idx)" 
+                                <button x-on:click="handleSave(idx)"
                                         type="button" 
                                         :disabled="savingEvents[idx] || !canCreateAccount"
                                         :class="['px-4 py-2 rounded-md transition-colors', 
@@ -424,8 +424,8 @@
                                     <span v-else>{{ __('messages.save') }}</span>
                                 </button>
                                 <!--
-                                <button v-if="isCurator && preview.parsed[idx].event_url && !preview.parsed[idx].is_curated && !{{ isset($isGuest) && $isGuest ? 'true' : 'false' }}" 
-                                        @click="handleCurate(idx)" 
+                                <button v-if="isCurator && preview.parsed[idx].event_url && !preview.parsed[idx].is_curated && !{{ isset($isGuest) && $isGuest ? 'true' : 'false' }}"
+                                        x-on:click="handleCurate(idx)"
                                         type="button" 
                                         class="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 transition-colors">
                                     {{ __('messages.curate') }}
@@ -456,7 +456,7 @@
                                 
                                 <!-- Remove image button -->
                                 <button v-if="!isLoading"
-                                        @click="removeImage(idx)" 
+                                        x-on:click="removeImage(idx)"
                                         type="button"
                                         v-bind:disabled="savedEvents[idx]"
                                         class="absolute top-2 right-2 p-1 bg-red-500 text-white rounded-full hover:bg-red-600 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed">
@@ -468,10 +468,10 @@
 
                             <!-- Drop zone -->
                             <div v-else-if="!savedEvents[idx]"
-                                    @dragover.prevent="dragOver"
-                                    @dragleave.prevent="dragLeave"
-                                    @drop.prevent="(e) => handleDrop(e, idx)"
-                                    @click="() => openFileSelector(idx)"
+                                    x-on:dragover.prevent="dragOver"
+                                    x-on:dragleave.prevent="dragLeave"
+                                    x-on:drop.prevent="(e) => handleDrop(e, idx)"
+                                    x-on:click="() => openFileSelector(idx)"
                                     v-bind:class="['flex-grow flex items-center justify-center rounded-lg border-2 border-dashed cursor-pointer', 
                                             isDragging ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30' : 'border-gray-300 dark:border-gray-600']">
                                 <div class="text-center py-10">
@@ -499,9 +499,9 @@
                             </div>
 
                             <!-- Hidden file input -->
-                            <input type="file" 
+                            <input type="file"
                                     v-bind:ref="'fileInput_' + idx"
-                                    @change="(e) => handleFileSelect(e, idx)"
+                                    x-on:change="(e) => handleFileSelect(e, idx)"
                                     accept="image/*"
                                     class="hidden">
                         </div>
@@ -529,7 +529,7 @@
                                     <div v-for="video in performer.videos.slice(0, 6)" :key="video.id" 
                                             class="border rounded-lg p-2 cursor-pointer hover:border-blue-300 transition-colors relative"
                                             :class="isVideoSelected(idx, performerIdx, video) ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/30' : 'border-gray-200 dark:border-gray-600'"
-                                            @click="selectVideo(idx, performerIdx, video)">
+                                            x-on:click="selectVideo(idx, performerIdx, video)">
                                         <div class="flex items-center space-x-3">
                                             <div class="w-16 h-12 bg-gray-100 dark:bg-gray-700 rounded flex items-center justify-center relative flex-shrink-0">
                                                 <img v-if="video.thumbnail" :src="video.thumbnail" :alt="video.title" class="w-full h-full object-cover rounded">
@@ -561,7 +561,7 @@
                                             <!-- Watch button -->
                                             <a :href="video.url" target="_blank" 
                                                 class="inline-flex items-center text-xs text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 font-medium transition-colors flex-shrink-0"
-                                                @click.stop>
+                                                x-on:click.stop>
                                                 <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 24 24">
                                                     <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
                                                 </svg>

--- a/resources/views/event/tickets.blade.php
+++ b/resources/views/event/tickets.blade.php
@@ -212,7 +212,7 @@
                     <p v-else>
                     <select 
                         v-model="ticket.selectedQty"
-                        @change="updateTicketQuantities"
+                        x-on:change="updateTicketQuantities"
                         class="block w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
                         :name="`tickets[${ticket.id}]`" :id="`ticket-${index}`"
                     >

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -128,7 +128,7 @@
                         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('messages.events') }}</h2>
                     </div>
                     @if ($creationRoles->isNotEmpty())
-                        <x-primary-button type="button" x-data="" @click="$dispatch('open-modal', 'create-event')">
+                        <x-primary-button type="button" x-data="" x-on:click="$dispatch('open-modal', 'create-event')">
                             {{ __('messages.add_event') }}
                         </x-primary-button>
                     @endif
@@ -285,7 +285,7 @@
                             curators: @js($curatorOptions),
                         })"
                         class="mt-5 space-y-5"
-                        @submit.prevent="submit">
+                        x-on:submit.prevent="submit">
 
                         <div>
                             <x-input-label for="event-create-role" :value="__('messages.schedule')" />
@@ -336,7 +336,7 @@
                         </div>
 
                         <div class="flex justify-end space-x-3">
-                            <x-secondary-button type="button" @click="$dispatch('close-modal', 'create-event')">{{ __('messages.cancel') }}</x-secondary-button>
+                            <x-secondary-button type="button" x-on:click="$dispatch('close-modal', 'create-event')">{{ __('messages.cancel') }}</x-secondary-button>
                             <x-primary-button type="submit" x-bind:disabled="! canSubmit">
                                 {{ __('messages.next') }}
                             </x-primary-button>

--- a/resources/views/role/contacts.blade.php
+++ b/resources/views/role/contacts.blade.php
@@ -25,7 +25,7 @@
                         </a>
                     </div>
 
-                    <button type="button" x-data="" @click="$dispatch('open-modal', 'add-contact')"
+                    <button type="button" x-data="" x-on:click="$dispatch('open-modal', 'add-contact')"
                         class="inline-flex items-center justify-center gap-2 rounded-md bg-[#4E81FA] px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#3a6ad6] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA]">
                         <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -123,7 +123,7 @@
                                                 </td>
                                                 <td class="whitespace-nowrap px-3 py-4 text-right text-sm text-gray-900 dark:text-gray-100">
                                                     <div class="flex justify-end gap-2">
-                                                        <button type="button" x-data="" @click="$dispatch('open-modal', '{{ $modalName }}')"
+                                                        <button type="button" x-data="" x-on:click="$dispatch('open-modal', '{{ $modalName }}')"
                                                             class="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800">
                                                             <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                                                                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687 1.688a1.875 1.875 0 010 2.652l-9.545 9.546-4.06.451.451-4.06 9.546-9.545a1.875 1.875 0 012.652 0z" />
@@ -178,7 +178,7 @@
 
                                                     <div class="flex justify-end gap-3">
                                                         <button type="button" class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
-                                                            @click="$dispatch('close-modal', '{{ $modalName }}')">
+                                                            x-on:click="$dispatch('close-modal', '{{ $modalName }}')">
                                                             {{ __('messages.cancel') }}
                                                         </button>
                                                         <button type="submit"
@@ -267,7 +267,7 @@
 
             <div class="flex justify-end gap-3">
                 <button type="button" class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800"
-                    @click="$dispatch('close-modal', 'add-contact')">
+                    x-on:click="$dispatch('close-modal', 'add-contact')">
                     {{ __('messages.cancel') }}
                 </button>
                 <button type="submit"

--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -203,7 +203,7 @@
                     </button>
                 </a>
             @elseif ($route == 'home' && ($canCreateEvent ?? false))
-                <button type="button" x-data="" @click="$dispatch('open-modal', 'create-event')"
+                <button type="button" x-data="" x-on:click="$dispatch('open-modal', 'create-event')"
                     class="w-full md:w-auto inline-flex items-center justify-center rounded-md shadow-sm bg-[#4E81FA] px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#3A6BE0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA]">
                     <svg class="{{ isset($role) && $role->isRtl() && ! session()->has('translate') ? '-mr-0.5 ml-1.5' : '-ml-0.5 mr-1.5' }} h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
@@ -279,7 +279,7 @@
                                 <a :href="getEventUrl(event, '{{ $currentDate->format('Y-m-d') }}')"
                                     class="flex has-tooltip" 
                                     :data-tooltip="getEventTooltip(event)"
-                                    @click.stop {{ ($route != 'guest' || (isset($embed) && $embed)) ? "target='_blank'" : '' }}>
+                                    x-on:click.stop {{ ($route != 'guest' || (isset($embed) && $embed)) ? "target='_blank'" : '' }}>
                                     <p class="flex-auto font-medium group-hover:text-[#4E81FA] text-gray-900 {{ (isset($role) && $role->isRtl()) ? 'rtl' : '' }} truncate">
                                         <span :class="getEventsForDate('{{ $currentDate->format('Y-m-d') }}').filter(e => isEventVisible(e)).length == 1 ? 'line-clamp-2' : 'line-clamp-1'" 
                                               class="hover:underline truncate" v-text="getEventDisplayName(event)">
@@ -291,7 +291,7 @@
                                 </a>
                                 <a v-if="event.can_edit" :href="event.edit_url"
                                     class="absolute {{ (isset($role) && $role->isRtl()) ? 'left-0' : 'right-0' }} top-0 hidden group-hover:inline-block text-[#4E81FA] hover:text-[#4E81FA] hover:underline"
-                                    @click.stop>
+                                    x-on:click.stop>
                                     {{ __('messages.edit') }}
                                 </a>
                             </li>
@@ -360,7 +360,7 @@
                                     <img v-if="event.image_url" :src="event.image_url" class="h-16 w-16 flex-none rounded-lg object-cover mb-2">
                                     <a v-if="event.can_edit" :href="event.edit_url"
                                         class="text-[#4E81FA] hover:text-[#4E81FA] hover:underline"
-                                        @click.stop>
+                                        x-on:click.stop>
                                         {{ __('messages.edit') }}
                                     </a>
                                 </div>

--- a/resources/views/role/show-admin-videos.blade.php
+++ b/resources/views/role/show-admin-videos.blade.php
@@ -42,7 +42,7 @@
                                 <div v-for="video in role.videos" :key="video.id" 
                                         class="border rounded-lg p-3 cursor-pointer hover:border-blue-300 transition-colors relative"
                                         :class="isVideoSelected(role, video) ? 'border-blue-500 bg-blue-50' : 'border-gray-200'"
-                                        @click="selectVideo(role, video)">
+                                        x-on:click="selectVideo(role, video)">
                                     <div class="aspect-video bg-gray-100 rounded mb-2 flex items-center justify-center relative">
                                         <img v-if="video.thumbnail" :src="video.thumbnail" :alt="video.title" class="w-full h-full object-cover rounded">
                                         <svg v-else class="h-8 w-8 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -74,7 +74,7 @@
                                         <!-- Watch button -->
                                         <a :href="video.url" target="_blank" 
                                             class="inline-flex items-center text-xs text-red-600 hover:text-red-700 font-medium transition-colors"
-                                            @click.stop>
+                                            x-on:click.stop>
                                             <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 24 24">
                                                 <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
                                             </svg>
@@ -96,11 +96,11 @@
                             <div v-if="role.selectedVideos && role.selectedVideos.length > 0" class="mt-4">
                                 <div class="flex items-center justify-between">
                                     <div class="flex items-center space-x-3">
-                                        <button @click="skipRole(role)" 
+                                        <button x-on:click="skipRole(role)"
                                                 class="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
                                             {{ __('messages.skip') }}
                                         </button>
-                                        <button @click="saveVideos(role)" 
+                                        <button x-on:click="saveVideos(role)"
                                                 class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
                                             {{ __('messages.save_videos') }}
                                         </button>
@@ -113,7 +113,7 @@
                                     <div class="text-sm text-gray-600">
                                         {{ __('messages.no_videos_selected') }}
                                     </div>
-                                    <button @click="skipRole(role)" 
+                                    <button x-on:click="skipRole(role)"
                                             class="inline-flex items-center px-3 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
                                         {{ __('messages.skip') }}
                                     </button>
@@ -127,7 +127,7 @@
                         
                         <div v-else class="text-sm text-gray-500">
                             {{ __('messages.no_videos_found') }}
-                            <button @click="skipRole(role)" 
+                            <button x-on:click="skipRole(role)"
                                     class="ml-3 inline-flex items-center px-3 py-1 border border-gray-300 text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
                                 {{ __('messages.skip') }}
                             </button>

--- a/resources/views/ticket/sales_table.blade.php
+++ b/resources/views/ticket/sales_table.blade.php
@@ -114,7 +114,7 @@
                                                 dropdown.style.zIndex = '1000';
                                             }
                                         }">
-                                            <button @click="open = !open; $nextTick(() => positionDropdown())" 
+                                            <button x-on:click="open = !open; $nextTick(() => positionDropdown())"
                                                     x-ref="button"
                                                     type="button" 
                                                     class="inline-flex items-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 transition-colors duration-150">
@@ -126,7 +126,7 @@
 
                                             <div x-show="open" 
                                                  x-ref="dropdown"
-                                                 @click.away="open = false"
+                                                   x-on:click.away="open = false"
                                                  class="w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
                                                  role="menu" 
                                                  x-cloak
@@ -134,14 +134,14 @@
                                                 
                                                 <a href="{{ route('ticket.view', ['event_id' => \App\Utils\UrlUtils::encodeId($sale->event_id), 'secret' => $sale->secret]) }}" 
                                                    target="_blank" 
-                                                   @click="open = false"
+                                                     x-on:click="open = false"
                                                    class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150"
                                                    role="menuitem">
                                                     {{ __('messages.view_ticket') }}
                                                 </a>
 
                                                 @if($sale->status === 'unpaid')
-                                                    <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'mark_paid')" 
+                                                      <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'mark_paid')"
                                                             class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                                             role="menuitem">
                                                         {{ __('messages.mark_paid') }}
@@ -149,7 +149,7 @@
                                                 @endif
 
                                                 @if(false && $sale->status === 'paid' && $sale->payment_method != 'cash')
-                                                    <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'refund')" 
+                                                      <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'refund')"
                                                             class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                                             role="menuitem">
                                                         {{ __('messages.refund') }}
@@ -157,7 +157,7 @@
                                                 @endif
 
                                                 @if(in_array($sale->status, ['unpaid', 'paid']))
-                                                    <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'cancel')" 
+                                                      <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'cancel')"
                                                             class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                                             role="menuitem">
                                                         {{ __('messages.cancel') }}
@@ -165,7 +165,7 @@
                                                 @endif
                                                 
                                                 @if(! $sale->is_deleted)
-                                                <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'delete')" 
+                                                <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'delete')"
                                                         class="block px-4 py-2 text-sm text-red-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                                         role="menuitem">
                                                         {{ __('messages.delete') }}
@@ -281,7 +281,7 @@
                             dropdown.style.zIndex = '1000';
                         }
                     }">
-                        <button @click="open = !open; $nextTick(() => positionDropdown())" 
+                        <button x-on:click="open = !open; $nextTick(() => positionDropdown())"
                                 x-ref="button"
                                 type="button" 
                                 class="w-full inline-flex items-center justify-center rounded-lg bg-blue-50 px-4 py-3 text-sm font-semibold text-blue-700 shadow-sm ring-1 ring-inset ring-blue-200 hover:bg-blue-100 transition-colors duration-150">
@@ -293,7 +293,7 @@
 
                         <div x-show="open" 
                              x-ref="dropdown"
-                             @click.away="open = false"
+                             x-on:click.away="open = false"
                              class="w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" 
                              role="menu" 
                              x-cloak
@@ -301,14 +301,14 @@
                             
                             <a href="{{ route('ticket.view', ['event_id' => \App\Utils\UrlUtils::encodeId($sale->event_id), 'secret' => $sale->secret]) }}" 
                                target="_blank" 
-                               @click="open = false"
+                               x-on:click="open = false"
                                class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150"
                                role="menuitem">
                                 {{ __('messages.view_ticket') }}
                             </a>
 
                             @if($sale->status === 'unpaid')
-                                <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'mark_paid')" 
+                                <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'mark_paid')"
                                         class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                         role="menuitem">
                                     {{ __('messages.mark_paid') }}
@@ -316,7 +316,7 @@
                             @endif
 
                             @if(false && $sale->status === 'paid' && $sale->payment_method != 'cash')
-                                <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'refund')" 
+                                <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'refund')"
                                         class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                         role="menuitem">
                                     {{ __('messages.refund') }}
@@ -324,7 +324,7 @@
                             @endif
 
                             @if(in_array($sale->status, ['unpaid', 'paid']))
-                                <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'cancel')" 
+                                <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'cancel')"
                                         class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                         role="menuitem">
                                     {{ __('messages.cancel') }}
@@ -332,7 +332,7 @@
                             @endif
                             
                             @if(! $sale->is_deleted)
-                            <button @click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'delete')" 
+                            <button x-on:click="open = false; handleAction('{{ \App\Utils\UrlUtils::encodeId($sale->id) }}', 'delete')"
                                     class="block px-4 py-2 text-sm text-red-700 hover:bg-gray-100 w-full text-left transition-colors duration-150" 
                                     role="menuitem">
                                 {{ __('messages.delete') }}

--- a/resources/views/ticket/scan.blade.php
+++ b/resources/views/ticket/scan.blade.php
@@ -90,7 +90,7 @@
 
                 </div>
 
-                <button @click="startNewScan" class="mt-6 bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors">
+                <button x-on:click="startNewScan" class="mt-6 bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors">
                         {{ __('messages.scan_another_ticket') }}
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- replace Alpine/Livewire-style Blade `@` event handlers with `x-on:` equivalents across dropdowns, event management forms, ticket workflows, and role views to prevent parse errors
- leave server-side Blade directives untouched while ensuring Alpine interactions continue to function as before

## Testing
- php artisan test *(fails: missing `vendor/autoload.php`; `composer install` requires GitHub access and cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f70598a650832eaf6231800ea46537