### PR TITLE
Fix blade parsing for step indicator styles

### DIFF
--- a/resources/views/components/step-indicator.blade.php
+++ b/resources/views/components/step-indicator.blade.php
@@ -149,7 +149,7 @@
 }
 
 /* Enhanced animations */
-@keyframes pulse-glow {
+@@keyframes pulse-glow {
     0% {
         box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4);
     }
@@ -163,7 +163,7 @@
 }
 
 /* Responsive improvements */
-@media (max-width: 640px) {
+@@media (max-width: 640px) {
     .step-indicator {
         padding: 1rem;
         margin: 1rem 0;


### PR DESCRIPTION
## Summary
- escape CSS `@keyframes` and `@media` directives in the step indicator component so Blade renders them literally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f78fb5d8f4832eafcf7afde3d3b8fd