### PR TITLE
Escape Blade directives in scan ticket styles

### DIFF
--- a/resources/views/ticket/scan.blade.php
+++ b/resources/views/ticket/scan.blade.php
@@ -14,14 +14,14 @@
                 border-radius: 1rem !important;
             }
             #html5-qrcode-button-camera-permission {
-                @apply bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors;
+                @@apply bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors;
             }
-            #html5-qrcode-button-camera-start, 
+            #html5-qrcode-button-camera-start,
             #html5-qrcode-button-camera-stop {
-                @apply bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 transition-colors mt-2;
+                @@apply bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 transition-colors mt-2;
             }
             .html5-qrcode-element {
-                @apply mb-4;
+                @@apply mb-4;
             }
         </style>
     


### PR DESCRIPTION
## Summary
- escape Tailwind `@apply` directives in the scan ticket view so Blade outputs the intended CSS

## Testing
- not run (environment lacks PHP dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68f7a251924c832ebd01ac51d4adf36e