### PR TITLE
Fix Blade inline styles escaping to prevent parse error

### DIFF
--- a/resources/views/components/step-indicator.blade.php
+++ b/resources/views/components/step-indicator.blade.php
@@ -122,6 +122,7 @@
     
 </div>
 
+@verbatim
 <style>
 .step-indicator {
     background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
@@ -149,7 +150,7 @@
 }
 
 /* Enhanced animations */
-@@keyframes pulse-glow {
+@keyframes pulse-glow {
     0% {
         box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4);
     }
@@ -163,16 +164,16 @@
 }
 
 /* Responsive improvements */
-@@media (max-width: 640px) {
+@media (max-width: 640px) {
     .step-indicator {
         padding: 1rem;
         margin: 1rem 0;
     }
-    
+
     .step-indicator .flex {
         gap: 0.75rem;
     }
-    
+
     .step-indicator .space-x-6 {
         gap: 0.75rem;
     }
@@ -184,8 +185,9 @@
 }
 
 /* Hover effects */
-.step-indicator .hover\\:scale-110:hover {
+.step-indicator .hover\:scale-110:hover {
     transform: scale(1.1);
     transition: transform 0.2s ease;
 }
-</style> 
+</style>
+@endverbatim

--- a/resources/views/ticket/scan.blade.php
+++ b/resources/views/ticket/scan.blade.php
@@ -5,25 +5,27 @@
         <script src="{{ asset('js/vue.global.prod.js') }}"></script>
         <script src="{{ asset('js/html5-qrcode.min.js') }}"></script>
 
-        <style>
-            #reader {
-                border: none !important;
-                box-shadow: none !important;
-            }
-            #reader video {
-                border-radius: 1rem !important;
-            }
-            #html5-qrcode-button-camera-permission {
-                @@apply bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors;
-            }
-            #html5-qrcode-button-camera-start,
-            #html5-qrcode-button-camera-stop {
-                @@apply bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 transition-colors mt-2;
-            }
-            .html5-qrcode-element {
-                @@apply mb-4;
-            }
-        </style>
+        @verbatim
+            <style>
+                #reader {
+                    border: none !important;
+                    box-shadow: none !important;
+                }
+                #reader video {
+                    border-radius: 1rem !important;
+                }
+                #html5-qrcode-button-camera-permission {
+                    @apply bg-blue-500 text-white px-4 py-2 rounded-lg hover:bg-blue-600 transition-colors;
+                }
+                #html5-qrcode-button-camera-start,
+                #html5-qrcode-button-camera-stop {
+                    @apply bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 transition-colors mt-2;
+                }
+                .html5-qrcode-element {
+                    @apply mb-4;
+                }
+            </style>
+        @endverbatim
     
     </x-slot>
 


### PR DESCRIPTION
## Summary
- wrap inline style blocks in Blade templates with `@verbatim` to prevent directive parsing
- remove escaped `@@` prefixes now that the styles render verbatim so CSS directives like `@apply` and `@keyframes` remain intact

## Testing
- not run (composer install blocked by network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68f7a959ff74832e93602eedc85cd408