### PR TITLE
Fix image uploads to use the correct public storage disk

### DIFF
--- a/app/Http/Controllers/Api/ApiEventController.php
+++ b/app/Http/Controllers/Api/ApiEventController.php
@@ -205,21 +205,22 @@ class ApiEventController extends Controller
         }
 
         if ($request->hasFile('flyer_image')) {
+            $disk = storage_public_disk();
+
             if ($event->flyer_image_url) {
-                $path = $event->getAttributes()['flyer_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($event->getAttributes()['flyer_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('flyer_image');
             $filename = strtolower('flyer_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $event->flyer_image_url = $filename;
             $event->save();
-        }        
+        }
         
         return response()->json([
             'data' => $event->toApiData(),

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -48,17 +48,18 @@ class EventController extends Controller
             return redirect()->back()->with('error', __('messages.not_authorized'));
         }
 
+        $disk = storage_public_disk();
+
         if ($request->image_type == 'flyer') {
             if ($event->flyer_image_url) {
-                $path = $event->getAttributes()['flyer_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($event->getAttributes()['flyer_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
 
                 $event->flyer_image_url = null;
                 $event->save();
-            }    
+            }
         }
 
         return redirect(route('event.edit', ['subdomain' => $subdomain, 'hash' => $request->hash]))
@@ -928,7 +929,8 @@ class EventController extends Controller
         if ($request->social_image) {
             $file = new \Illuminate\Http\UploadedFile($request->social_image, basename($request->social_image));
             $filename = strtolower('flyer_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $disk = storage_public_disk();
+            $file->storeAs('', $filename, $disk);
 
             $event->flyer_image_url = $filename;
             $event->save();
@@ -957,7 +959,8 @@ class EventController extends Controller
         if ($request->social_image) {
             $file = new \Illuminate\Http\UploadedFile($request->social_image, basename($request->social_image));
             $filename = strtolower('flyer_' . Str::random(32)) . '.' . $file->getClientOriginalExtension();
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $disk = storage_public_disk();
+            $file->storeAs('', $filename, $disk);
 
             $event->flyer_image_url = $filename;
             $event->save();

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -39,19 +39,19 @@ class ProfileController extends Controller
 
         if ($request->hasFile('profile_image')) {
             $user = $request->user();
-            
+            $disk = storage_public_disk();
+
             if ($user->profile_image_url) {
-                $path = $user->getAttributes()['profile_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($user->getAttributes()['profile_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('profile_image');
             $filename = strtolower('profile_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
-            
+            $file->storeAs('', $filename, $disk);
+
             $user->profile_image_url = $filename;
             $user->save();
         }
@@ -73,40 +73,38 @@ class ProfileController extends Controller
 
         Auth::logout();
 
+        $disk = storage_public_disk();
+
         if ($user->profile_image_url) {
-            $path = $user->getAttributes()['profile_image_url'];
-            if (config('filesystems.default') == 'local') {
-                $path = 'public/' . $path;
+            $path = storage_normalize_path($user->getAttributes()['profile_image_url']);
+            if ($path !== '') {
+                Storage::disk($disk)->delete($path);
             }
-            Storage::delete($path);
         }
 
         $roles = $user->owner()->get();
 
         foreach ($roles as $role) {
             if ($role->profile_image_url) {
-                $path = $role->getAttributes()['profile_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['profile_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
-    
+
             if ($role->header_image_url) {
-                $path = $role->getAttributes()['header_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['header_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
-    
+
             if ($role->background_image_url) {
-                $path = $role->getAttributes()['background_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['background_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
-            }    
+            }
         }
 
         $user->delete();

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -60,35 +60,34 @@ class RoleController extends Controller
             return redirect()->back()->with('error', __('messages.not_authorized'));
         }
 
+        $disk = storage_public_disk();
+
         if ($request->image_type == 'profile') {
             if ($role->profile_image_url) {
-                $path = $role->getAttributes()['profile_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['profile_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
 
                 $role->profile_image_url = null;
                 $role->save();
-            }    
+            }
         } else if ($request->image_type == 'background') {
             if ($role->background_image_url) {
-                $path = $role->getAttributes()['background_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['background_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
 
                 $role->background_image_url = null;
                 $role->save();
-            }    
+            }
         } else if ($request->image_type == 'header') {
             if ($role->header_image_url) {
-                $path = $role->getAttributes()['header_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['header_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
 
                 $role->header_image_url = null;
                 $role->save();
@@ -109,28 +108,27 @@ class RoleController extends Controller
             return redirect()->back()->with('error', __('messages.not_authorized'));
         }
 
+        $disk = storage_public_disk();
+
         if ($role->profile_image_url) {
-            $path = $role->getAttributes()['profile_image_url'];
-            if (config('filesystems.default') == 'local') {
-                $path = 'public/' . $path;
+            $path = storage_normalize_path($role->getAttributes()['profile_image_url']);
+            if ($path !== '') {
+                Storage::disk($disk)->delete($path);
             }
-            Storage::delete($path);
         }
 
         if ($role->header_image_url) {
-            $path = $role->getAttributes()['header_image_url'];
-            if (config('filesystems.default') == 'local') {
-                $path = 'public/' . $path;
+            $path = storage_normalize_path($role->getAttributes()['header_image_url']);
+            if ($path !== '') {
+                Storage::disk($disk)->delete($path);
             }
-            Storage::delete($path);
         }
 
         if ($role->background_image_url) {
-            $path = $role->getAttributes()['background_image_url'];
-            if (config('filesystems.default') == 'local') {
-                $path = 'public/' . $path;
+            $path = storage_normalize_path($role->getAttributes()['background_image_url']);
+            if ($path !== '') {
+                Storage::disk($disk)->delete($path);
             }
-            Storage::delete($path);
         }
 
         $emails = $role->members()->pluck('email');
@@ -1026,18 +1024,19 @@ class RoleController extends Controller
 
         $user->roles()->attach($role->id, ['created_at' => now(), 'level' => 'owner']);
 
+        $disk = storage_public_disk();
+
         if ($request->hasFile('profile_image')) {
             if ($role->profile_image_url) {
-                $path = $role->getAttributes()['profile_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['profile_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('profile_image');
             $filename = strtolower('profile_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $role->profile_image_url = $filename;
             $role->save();
@@ -1045,16 +1044,15 @@ class RoleController extends Controller
 
         if ($request->hasFile('header_image')) {
             if ($role->header_image_url) {
-                $path = $role->getAttributes()['header_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['header_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('header_image');
             $filename = strtolower('header_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $role->header_image_url = $filename;
             $role->save();
@@ -1065,16 +1063,15 @@ class RoleController extends Controller
             $role->save();
         } elseif ($role->background == 'image' && $request->hasFile('background_image_url')) {
             if ($role->background_image_url) {
-                $path = $role->getAttributes()['background_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['background_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('background_image_url');
             $filename = strtolower('background_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $role->background_image_url = $filename;
             $role->save();
@@ -1291,18 +1288,19 @@ class RoleController extends Controller
             $role->groups()->whereIn('id', $toDelete)->delete();
         }
 
+        $disk = storage_public_disk();
+
         if ($request->hasFile('profile_image')) {
             if ($role->profile_image_url) {
-                $path = $role->getAttributes()['profile_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['profile_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
-        
+
             $file = $request->file('profile_image');
             $filename = strtolower('profile_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $role->profile_image_url = $filename;
             $role->save();
@@ -1310,16 +1308,15 @@ class RoleController extends Controller
 
         if ($request->hasFile('header_image_url')) {
             if ($role->header_image_url) {
-                $path = $role->getAttributes()['header_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['header_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('header_image_url');
             $filename = strtolower('header_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $role->header_image_url = $filename;
             $role->save();
@@ -1330,16 +1327,15 @@ class RoleController extends Controller
             $role->save();
         } elseif ($role->background == 'image' && $request->hasFile('background_image_url')) {
             if ($role->background_image_url) {
-                $path = $role->getAttributes()['background_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($role->getAttributes()['background_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('background_image_url');
             $filename = strtolower('background_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $role->background_image_url = $filename;
             $role->save();

--- a/app/Repos/EventRepo.php
+++ b/app/Repos/EventRepo.php
@@ -301,17 +301,18 @@ class EventRepo
         }
         
         if ($request->hasFile('flyer_image')) {
+            $disk = storage_public_disk();
+
             if ($event->flyer_image_url) {
-                $path = $event->getAttributes()['flyer_image_url'];
-                if (config('filesystems.default') == 'local') {
-                    $path = 'public/' . $path;
+                $path = storage_normalize_path($event->getAttributes()['flyer_image_url']);
+                if ($path !== '') {
+                    Storage::disk($disk)->delete($path);
                 }
-                Storage::delete($path);
             }
 
             $file = $request->file('flyer_image');
             $filename = strtolower('flyer_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+            $file->storeAs('', $filename, $disk);
 
             $event->flyer_image_url = $filename;
             $event->save();

--- a/app/Utils/ImageUtils.php
+++ b/app/Utils/ImageUtils.php
@@ -119,7 +119,8 @@ class ImageUtils
         $filename = strtolower($filenamePrefix . \Illuminate\Support\Str::random(32) . '.' . $extension);
         
         $file = new \Illuminate\Http\UploadedFile($tempFile, $filenamePrefix . '.' . $extension);
-        $path = $file->storeAs(config('filesystems.default') == 'local' ? '/public' : '/', $filename);
+        $disk = storage_public_disk();
+        $file->storeAs('', $filename, $disk);
 
         return $filename;
     }


### PR DESCRIPTION
## Summary
- add helpers to normalize stored file paths and resolve the public upload disk
- update controllers, repos, and utilities to store and delete uploads through the resolved disk
- ensure generated asset URLs use the normalized paths

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7bea5fd54832e97d74cd73e0792c0