### PR TITLE
Serve public storage files through controller

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -106,8 +106,8 @@ class RegisteredUserController extends Controller
             config(['database.connections.mysql.username' => $request->database_username]);
             config(['database.connections.mysql.password' => $request->database_password]);
             
-            Artisan::call('migrate', ['--force' => true]);      
-            Artisan::call('storage:link');
+            Artisan::call('migrate', ['--force' => true]);
+            Artisan::call('storage:link', ['--force' => true]);
         }        
 
         if (! config('app.hosted') && ! config('app.is_testing') && User::count() > 0) {

--- a/app/Http/Controllers/PublicStorageController.php
+++ b/app/Http/Controllers/PublicStorageController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class PublicStorageController extends Controller
+{
+    /**
+     * Stream a publicly accessible file stored on the configured filesystem disk.
+     */
+    public function __invoke(string $path): StreamedResponse
+    {
+        $normalized = storage_normalize_path($path);
+
+        if ($normalized === '' || str_contains($normalized, '..')) {
+            abort(404);
+        }
+
+        $diskName = storage_public_disk();
+        $disk = Storage::disk($diskName);
+
+        try {
+            if (! $disk->exists($normalized)) {
+                abort(404);
+            }
+
+            $stream = $disk->readStream($normalized);
+        } catch (\Throwable $exception) {
+            abort(404);
+        }
+
+        if (! is_resource($stream)) {
+            abort(404);
+        }
+
+        $mimeType = $disk->mimeType($normalized) ?: 'application/octet-stream';
+        $size = $disk->size($normalized);
+
+        $headers = [
+            'Content-Type' => $mimeType,
+            'Cache-Control' => 'public, max-age=604800',
+            'Content-Disposition' => 'inline; filename="' . basename($normalized) . '"',
+        ];
+
+        if (is_numeric($size)) {
+            $headers['Content-Length'] = (string) $size;
+        }
+
+        return response()->stream(function () use ($stream) {
+            try {
+                fpassthru($stream);
+            } finally {
+                if (is_resource($stream)) {
+                    fclose($stream);
+                }
+            }
+        }, 200, $headers);
+    }
+}
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\RoleController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\GraphicController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\PublicStorageController;
 use App\Http\Controllers\StripeController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\InvoiceNinjaController;
@@ -54,6 +55,10 @@ if (config('app.hosted')) {
     Route::match(['get', 'post'], '/update', [AppController::class, 'update'])->name('app.update');
     Route::post('/test_database', [AppController::class, 'testDatabase'])->name('app.test_database');
 }
+
+Route::get('/storage/{path}', PublicStorageController::class)
+    ->where('path', '.*')
+    ->name('storage.public');
 
 require __DIR__ . '/auth.php';
 

--- a/tests/Feature/PublicStorageControllerTest.php
+++ b/tests/Feature/PublicStorageControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PublicStorageControllerTest extends TestCase
+{
+    public function test_it_streams_files_from_the_public_disk(): void
+    {
+        Storage::fake('public');
+
+        $file = UploadedFile::fake()->image('profile.png', 32, 32);
+        $path = $file->storeAs('', 'profile.png', 'public');
+
+        $response = $this->get('/storage/' . $path);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'image/png');
+        $response->assertHeader('Cache-Control', 'public, max-age=604800');
+        $response->assertHeader('Content-Disposition', 'inline; filename="profile.png"');
+        $this->assertSame(Storage::disk('public')->get($path), $response->getContent());
+    }
+
+    public function test_it_accepts_requests_with_storage_prefix(): void
+    {
+        Storage::fake('public');
+
+        Storage::disk('public')->put('profile.png', 'avatar');
+
+        $response = $this->get('/storage/storage/profile.png');
+
+        $response->assertOk();
+        $this->assertSame('avatar', $response->getContent());
+    }
+
+    public function test_it_returns_not_found_for_missing_files(): void
+    {
+        Storage::fake('public');
+
+        $response = $this->get('/storage/missing.png');
+
+        $response->assertNotFound();
+    }
+
+    public function test_it_blocks_directory_traversal_attempts(): void
+    {
+        Storage::fake('public');
+
+        $response = $this->get('/storage/../.env');
+
+        $response->assertNotFound();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated controller that streams files from the configured public disk, bypassing web server symlink requirements
- register a catch-all /storage/{path} route so public assets are delivered even when the storage symlink is missing
- cover the new delivery path with feature tests to guard streaming, prefix normalization, and error handling

## Testing
- not run (repository dependencies require GitHub authentication in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f7d05d5e94832e9a1ebfb5f0c7de3b