### PR TITLE
Handle missing event start times gracefully

### DIFF
--- a/app/Http/Controllers/GraphicController.php
+++ b/app/Http/Controllers/GraphicController.php
@@ -155,6 +155,10 @@ class GraphicController extends Controller
         $currentDay = null;
         foreach ($events as $event) {
             $startDate = $event->getStartDateTime(null, true);
+
+            if (! $startDate) {
+                continue;
+            }
             $dayName = $startDate->format('l');
             $dateStr = $event->localStartsAt(true);
             

--- a/app/Services/GoogleCalendarService.php
+++ b/app/Services/GoogleCalendarService.php
@@ -182,13 +182,19 @@ class GoogleCalendarService
             $googleEvent->setDescription($description);
 
             // Set start and end times
+            $startAt = $event->getStartDateTime();
+
+            if (! $startAt) {
+                throw new \RuntimeException('Cannot sync event without a start time to Google Calendar.');
+            }
+
             $startDateTime = new EventDateTime();
-            $startDateTime->setDateTime($event->getStartDateTime()->toRfc3339String());
+            $startDateTime->setDateTime($startAt->toRfc3339String());
             $startDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setStart($startDateTime);
 
             $endDateTime = new EventDateTime();
-            $endTime = $event->getStartDateTime()->copy()->addHours($event->duration ?: 2);
+            $endTime = $startAt->copy()->addHours($event->duration ?: 2);
             $endDateTime->setDateTime($endTime->toRfc3339String());
             $endDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setEnd($endDateTime);
@@ -253,13 +259,19 @@ class GoogleCalendarService
             $googleEvent->setDescription($description);
 
             // Set start and end times
+            $startAt = $event->getStartDateTime();
+
+            if (! $startAt) {
+                throw new \RuntimeException('Cannot sync event without a start time to Google Calendar.');
+            }
+
             $startDateTime = new EventDateTime();
-            $startDateTime->setDateTime($event->getStartDateTime()->toRfc3339String());
+            $startDateTime->setDateTime($startAt->toRfc3339String());
             $startDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setStart($startDateTime);
 
             $endDateTime = new EventDateTime();
-            $endTime = $event->getStartDateTime()->copy()->addHours($event->duration ?: 2);
+            $endTime = $startAt->copy()->addHours($event->duration ?: 2);
             $endDateTime->setDateTime($endTime->toRfc3339String());
             $endDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setEnd($endDateTime);

--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -184,6 +184,11 @@ class AppleWalletService
     protected function resolveEventStart(Event $event, ?string $eventDate): Carbon
     {
         $startsAt = $event->getStartDateTime($eventDate);
+
+        if (! $startsAt) {
+            throw new \RuntimeException('Cannot build wallet pass for event without a start time.');
+        }
+
         $timezone = $this->resolveTimezone($event);
 
         return $startsAt->clone()->setTimezone($timezone);
@@ -198,7 +203,19 @@ class AppleWalletService
 
     protected function formatDisplayDate(Event $event, ?string $eventDate): string
     {
-        return $event->localStartsAt(true, $eventDate) ?: $event->getStartDateTime($eventDate)->format('F j, Y g:i A');
+        $localized = $event->localStartsAt(true, $eventDate);
+
+        if ($localized) {
+            return $localized;
+        }
+
+        $startsAt = $event->getStartDateTime($eventDate, true);
+
+        if ($startsAt) {
+            return $startsAt->format('F j, Y g:i A');
+        }
+
+        return __('messages.unscheduled');
     }
 
     /**

--- a/app/Services/Wallet/GoogleWalletService.php
+++ b/app/Services/Wallet/GoogleWalletService.php
@@ -255,6 +255,11 @@ class GoogleWalletService
     protected function resolveEventStart(Event $event, ?string $eventDate): Carbon
     {
         $startsAt = $event->getStartDateTime($eventDate);
+
+        if (! $startsAt) {
+            throw new \RuntimeException('Cannot build wallet pass for event without a start time.');
+        }
+
         $timezone = $this->resolveTimezone($event);
 
         return $startsAt->clone()->setTimezone($timezone);

--- a/resources/views/event/show-guest.blade.php
+++ b/resources/views/event/show-guest.blade.php
@@ -239,7 +239,12 @@
             </a>
           </div>
           @endif
-          @if ($event->isMultiDay())
+          @php
+            $startAt = $event->getStartDateTime($date, true);
+            $endAt = $startAt && $event->duration > 0 ? $startAt->copy()->addHours($event->duration) : null;
+          @endphp
+
+          @if ($startAt && $event->isMultiDay())
           <div
             class="flex flex-row gap-2 items-center relative text-white fill-white sm:pr-4 sm:after:content-[''] sm:after:block sm:after:absolute sm:after:right-0 sm:after:top-[50%] sm:after:translate-y-[-50%] sm:after:h-[12px] sm:after:w-[1px] sm:after:bg-white"
           >
@@ -258,10 +263,10 @@
                 d="M2 12C2 11.161 2 10.4153 2.0129 9.75H21.9871C22 10.4153 22 11.161 22 12V14C22 17.7712 22 19.6569 20.8284 20.8284C19.6569 22 17.7712 22 14 22H10C6.22876 22 4.34315 22 3.17157 20.8284C2 19.6569 2 17.7712 2 14V12ZM17 14C17.5523 14 18 13.5523 18 13C18 12.4477 17.5523 12 17 12C16.4477 12 16 12.4477 16 13C16 13.5523 16.4477 14 17 14ZM17 18C17.5523 18 18 17.5523 18 17C18 16.4477 17.5523 16 17 16C16.4477 16 16 16.4477 16 17C16 17.5523 16.4477 18 17 18ZM13 13C13 13.5523 12.5523 14 12 14C11.4477 14 11 13.5523 11 13C11 12.4477 11.4477 12 12 12C12.5523 12 13 12.4477 13 13ZM13 17C13 17.5523 12.5523 18 12 18C11.4477 18 11 17.5523 11 17C11 16.4477 11.4477 16 12 16C12.5523 16 13 16.4477 13 17ZM7 14C7.55228 14 8 13.5523 8 13C8 12.4477 7.55228 12 7 12C6.44772 12 6 12.4477 6 13C6 13.5523 6.44772 14 7 14ZM7 18C7.55228 18 8 17.5523 8 17C8 16.4477 7.55228 16 7 16C6.44772 16 6 16.4477 6 17C6 17.5523 6.44772 18 7 18Z"
               />
             </svg>
-            <p class="text-sm">{{ $event->getStartDateTime($date, true)->format($event->getDateTimeFormat(true)) }} - {{ $event->getStartDateTime($date, true)->addHours($event->duration)->format($event->getDateTimeFormat()) }}</p>
+            <p class="text-sm">{{ $startAt->format($event->getDateTimeFormat(true)) }}@if ($endAt) - {{ $endAt->format($event->getDateTimeFormat()) }}@endif</p>
           </div>
 
-          @else
+          @elseif ($startAt)
           <div
             class="flex flex-row gap-2 items-center relative text-white fill-white sm:pr-4 sm:after:content-[''] sm:after:block sm:after:absolute sm:after:right-0 sm:after:top-[50%] sm:after:translate-y-[-50%] sm:after:h-[12px] sm:after:w-[1px] sm:after:bg-white"
           >
@@ -280,7 +285,7 @@
                 d="M2 12C2 11.161 2 10.4153 2.0129 9.75H21.9871C22 10.4153 22 11.161 22 12V14C22 17.7712 22 19.6569 20.8284 20.8284C19.6569 22 17.7712 22 14 22H10C6.22876 22 4.34315 22 3.17157 20.8284C2 19.6569 2 17.7712 2 14V12ZM17 14C17.5523 14 18 13.5523 18 13C18 12.4477 17.5523 12 17 12C16.4477 12 16 12.4477 16 13C16 13.5523 16.4477 14 17 14ZM17 18C17.5523 18 18 17.5523 18 17C18 16.4477 17.5523 16 17 16C16.4477 16 16 16.4477 16 17C16 17.5523 16.4477 18 17 18ZM13 13C13 13.5523 12.5523 14 12 14C11.4477 14 11 13.5523 11 13C11 12.4477 11.4477 12 12 12C12.5523 12 13 12.4477 13 13ZM13 17C13 17.5523 12.5523 18 12 18C11.4477 18 11 17.5523 11 17C11 16.4477 11.4477 16 12 16C12.5523 16 13 16.4477 13 17ZM7 14C7.55228 14 8 13.5523 8 13C8 12.4477 7.55228 12 7 12C6.44772 12 6 12.4477 6 13C6 13.5523 6.44772 14 7 14ZM7 18C7.55228 18 8 17.5523 8 17C8 16.4477 7.55228 16 7 16C6.44772 16 6 16.4477 6 17C6 17.5523 6.44772 18 7 18Z"
               />
             </svg>
-            <p class="text-sm">{{ $event->getStartDateTime($date, true)->format('F j, Y') }}</p>
+            <p class="text-sm">{{ $startAt->format('F j, Y') }}</p>
           </div>
           <div
             class="flex flex-row gap-2 items-center relative text-white fill-white sm:pr-4"
@@ -298,8 +303,26 @@
               />
             </svg>
             <p class="text-sm">
-              {{ $event->getStartEndTime($date) }}
+              {{ $event->getStartEndTime($date) ?: __('messages.unscheduled') }}
             </p>
+          </div>
+          @else
+          <div
+            class="flex flex-row gap-2 items-center relative text-white fill-white sm:pr-4"
+          >
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2ZM11 7C11 6.44772 11.4477 6 12 6C12.5523 6 13 6.44772 13 7V12C13 12.5523 12.5523 13 12 13H9C8.44772 13 8 12.5523 8 12C8 11.4477 8.44772 11 9 11H11V7ZM11 17C11 16.4477 11.4477 16 12 16H12.01C12.5623 16 13.01 16.4477 13.01 17C13.01 17.5523 12.5623 18 12.01 18H12C11.4477 18 11 17.5523 11 17Z"
+              />
+            </svg>
+            <p class="text-sm">{{ __('messages.unscheduled') }}</p>
           </div>
           @endif
         </div>

--- a/resources/views/ticket/view.blade.php
+++ b/resources/views/ticket/view.blade.php
@@ -77,7 +77,8 @@
               </defs>
             </svg>
 
-            <p class="text-[10px]">{{ $event->getStartDateTime($sale->date, true)->format('F j, Y') }}</p>
+            @php($ticketStartAt = $event->getStartDateTime($sale->date, true))
+            <p class="text-[10px]">{{ $ticketStartAt ? $ticketStartAt->format('F j, Y') : __('messages.unscheduled') }}</p>
           </div>
           <div class="flex gap-[8px] flex-row items-center">
             <svg
@@ -154,7 +155,7 @@
                 </clipPath>
               </defs>
             </svg>
-            <p class="text-[10px]">{{ $event->getStartEndTime($sale->date) }}</p>
+            <p class="text-[10px]">{{ $event->getStartEndTime($sale->date) ?: __('messages.unscheduled') }}</p>
           </div>
           <div class="flex gap-[8px] flex-row items-center">
             <svg


### PR DESCRIPTION
## Summary
- allow events without a stored start timestamp to return `null` from `getStartDateTime` and guard calendar URL builders
- skip unscheduled events when generating graphics and make wallet/calendar integrations fail fast with clear errors
- show an "Unscheduled" status in guest and ticket views when an event start time is unavailable

## Testing
- not run (vendor phpunit binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f7db829af4832e8d6d8ca887d77254