### PR TITLE
Ensure public disk visibility

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -40,6 +40,7 @@ return [
             'driver' => 'local',
             'root' => storage_path('app/public'),
             'url' => env('APP_URL').'/storage',
+            'visibility' => 'public',
             'throw' => false,
         ],
 


### PR DESCRIPTION
## Summary
- explicitly mark the local public filesystem disk as public to give generated uploads world-readable permissions

## Testing
- `php artisan test` *(fails: vendor autoload not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f7ee37d7f8832e90239ac29acd6959