### PR TITLE
Fix step indicator icon rendering to avoid Blade parse error

### DIFF
--- a/resources/views/components/step-indicator.blade.php
+++ b/resources/views/components/step-indicator.blade.php
@@ -42,25 +42,23 @@
                             </svg>
                         @elseif ($stepNumber == $currentStep)
                             <!-- Icon for current step -->
-                            @switch($steps[$stepNumber]['icon'])
-                                @case('user')
-                                    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"></path>
-                                    </svg>
-                                    @break
-                                @case('calendar')
-                                    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"></path>
-                                    </svg>
-                                    @break
-                                @case('plus')
-                                    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"></path>
-                                    </svg>
-                                    @break
-                                @default
-                                    {{ $i }}
-                            @endswitch
+                            @php($currentIcon = data_get($steps, [$stepNumber, 'icon']))
+
+                            @if ($currentIcon === 'user')
+                                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clip-rule="evenodd"></path>
+                                </svg>
+                            @elseif ($currentIcon === 'calendar')
+                                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"></path>
+                                </svg>
+                            @elseif ($currentIcon === 'plus')
+                                <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd"></path>
+                                </svg>
+                            @else
+                                {{ $i }}
+                            @endif
                         @else
                             {{ $stepNumber }}
                         @endif


### PR DESCRIPTION
## Summary
- replace the Blade `@switch` block in the step indicator component with explicit conditionals
- ensure the current step icon resolves without generating invalid compiled PHP

## Testing
- not run (phpunit, npm)


------
https://chatgpt.com/codex/tasks/task_e_68f7ef67322c832eb45f612e635a084d