### PR TITLE
Avoid unnecessary geocoding on role updates

### DIFF
--- a/tests/Unit/RoleGeocodingTest.php
+++ b/tests/Unit/RoleGeocodingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Role;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class RoleGeocodingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_updating_role_without_address_changes_does_not_trigger_geocode(): void
+    {
+        config(['services.google.backend' => 'test-key']);
+
+        Http::fake([
+            'https://maps.googleapis.com/maps/api/geocode/json*' => Http::response([
+                'status' => 'OK',
+                'results' => [
+                    [
+                        'geometry' => [
+                            'location' => ['lat' => '1.23', 'lng' => '4.56'],
+                        ],
+                        'formatted_address' => '123 Main St, Town, CA 90210, US',
+                        'place_id' => 'fake-place-id',
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $role = new Role([
+            'type' => 'venue',
+            'name' => 'Test Venue',
+            'email' => 'test-role@example.com',
+            'address1' => '123 Main St',
+            'city' => 'Town',
+            'state' => 'CA',
+            'postal_code' => '90210',
+            'country_code' => 'US',
+            'timezone' => 'UTC',
+        ]);
+        $role->subdomain = 'test-role';
+        $role->save();
+
+        Http::assertSentCount(1);
+
+        Http::fake();
+
+        $role->default_tickets = json_encode(['tickets' => []]);
+        $role->save();
+
+        Http::assertSentCount(0);
+    }
+}


### PR DESCRIPTION
## Summary
- only trigger Google Maps geocoding when a role's address changes and add HTTP timeouts with logging
- update the geocoding request to use Laravel's HTTP client for better control and failure handling
- add a unit test that verifies saving default ticket settings no longer performs a geocoding lookup

## Testing
- `composer install --no-interaction --no-progress` *(fails: network restrictions when cloning GitHub dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f81126028c832e9c0427e27e41a85a