### PR TITLE
Avoid named route parameters for absolute flag

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -33,7 +33,7 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended(route('home', absolute: false));
+        return redirect()->intended(route('home', [], false));
     }
 
     /**

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -35,6 +35,6 @@ class ConfirmablePasswordController extends Controller
 
         $request->session()->put('auth.password_confirmed_at', time());
 
-        return redirect()->intended(route('home', absolute: false));
+        return redirect()->intended(route('home', [], false));
     }
 }

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -14,7 +14,7 @@ class EmailVerificationNotificationController extends Controller
     public function store(Request $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('home', absolute: false));
+            return redirect()->intended(route('home', [], false));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -15,7 +15,7 @@ class EmailVerificationPromptController extends Controller
     public function __invoke(Request $request): RedirectResponse|View
     {
         return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(route('home', absolute: false))
+                    ? redirect()->intended(route('home', [], false))
                     : view('auth.verify-email');
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -141,6 +141,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user, true);
 
-        return redirect(route('home', absolute: false));
+        return redirect(route('home', [], false));
     }
 }

--- a/resources/views/settings/email.blade.php
+++ b/resources/views/settings/email.blade.php
@@ -36,7 +36,7 @@
                                     formData.delete('_method');
 
                                     try {
-                                        const response = await fetch('{{ route('settings.mail.test', absolute: false) }}', {
+                                        const response = await fetch('{{ route('settings.mail.test', [], false) }}', {
                                             method: 'POST',
                                             headers: {
                                                 'Accept': 'application/json',

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -27,7 +27,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('home', absolute: false));
+        $response->assertRedirect(route('home', [], false));
     }
 
     public function test_users_can_not_authenticate_with_invalid_password(): void

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -38,7 +38,7 @@ class EmailVerificationTest extends TestCase
 
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect(route('home', absolute: false));
+        $response->assertRedirect(route('home', [], false));
     }
 
     public function test_email_is_not_verified_with_invalid_hash(): void

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -41,7 +41,7 @@ class RegistrationTest extends TestCase
 
         $response
             ->assertSessionHasNoErrors()
-            ->assertRedirect(route('home', absolute: false))
+            ->assertRedirect(route('home', [], false))
         ;
 
         $this->assertAuthenticated();


### PR DESCRIPTION
## Summary
- replace named route arguments for the absolute flag with positional parameters in the auth controllers and tests
- update the email settings Blade view to request the mail test route without named arguments

## Testing
- php -l app/Http/Controllers/Auth/EmailVerificationNotificationController.php
- php -l app/Http/Controllers/Auth/EmailVerificationPromptController.php
- php -l app/Http/Controllers/Auth/ConfirmablePasswordController.php
- php -l app/Http/Controllers/Auth/AuthenticatedSessionController.php
- php -l app/Http/Controllers/Auth/RegisteredUserController.php
- php -l tests/Feature/Auth/AuthenticationTest.php
- php -l tests/Feature/Auth/EmailVerificationTest.php
- php -l tests/Feature/Auth/RegistrationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f8151e078c832ebba56e876b8ce010