### PR TITLE
Fix ticket view PHP directive syntax

### DIFF
--- a/resources/views/ticket/view.blade.php
+++ b/resources/views/ticket/view.blade.php
@@ -77,7 +77,9 @@
               </defs>
             </svg>
 
-            @php($ticketStartAt = $event->getStartDateTime($sale->date, true))
+            @php
+                $ticketStartAt = $event->getStartDateTime($sale->date, true);
+            @endphp
             <p class="text-[10px]">{{ $ticketStartAt ? $ticketStartAt->format('F j, Y') : __('messages.unscheduled') }}</p>
           </div>
           <div class="flex gap-[8px] flex-row items-center">


### PR DESCRIPTION
## Summary
- replace the single-line `@php()` directive in the ticket view with a standard block
- ensure the ticket start date calculation closes cleanly to prevent parse errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f8383bf910832ea66e71cc2f61d63a