### PR TITLE
Ensure public disk asset URLs stay on current host

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -216,6 +216,18 @@ if (!function_exists('storage_asset_url')) {
         $normalized = storage_normalize_path($path);
         $diskToUse = storage_public_disk();
 
+        if ($normalized !== '' && $diskToUse === 'public') {
+            try {
+                if (\Illuminate\Support\Facades\Route::has('storage.public')) {
+                    return route('storage.public', ['path' => $normalized], false);
+                }
+            } catch (\Throwable $exception) {
+                // Fall back to constructing the URL manually below.
+            }
+
+            return '/' . ltrim('storage/' . $normalized, '/');
+        }
+
         try {
             if (config()->has("filesystems.disks.{$diskToUse}")) {
                 return \Illuminate\Support\Facades\Storage::disk($diskToUse)->url($normalized);

--- a/tests/Unit/StorageAssetUrlTest.php
+++ b/tests/Unit/StorageAssetUrlTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+
+class StorageAssetUrlTest extends TestCase
+{
+    public function test_it_generates_relative_urls_for_public_disk(): void
+    {
+        config(['filesystems.default' => 'local']);
+
+        $this->assertSame('/storage/profile.png', storage_asset_url('profile.png'));
+    }
+}


### PR DESCRIPTION
## Summary
- update the storage_asset_url helper to return a host-agnostic URL when the public disk is in use, avoiding redirects to the APP_URL domain
- add a unit test covering the new behaviour for public disk URLs

## Testing
- not run (dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f83b359d2c832e92e604880ebd1037