### PR TITLE
Ensure public uploads are world-readable

### DIFF
--- a/app/Http/Controllers/Api/ApiEventController.php
+++ b/app/Http/Controllers/Api/ApiEventController.php
@@ -216,7 +216,7 @@ class ApiEventController extends Controller
 
             $file = $request->file('flyer_image');
             $filename = strtolower('flyer_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $event->flyer_image_url = $filename;
             $event->save();

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -936,7 +936,7 @@ class EventController extends Controller
             $file = new \Illuminate\Http\UploadedFile($request->social_image, basename($request->social_image));
             $filename = strtolower('flyer_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
             $disk = storage_public_disk();
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $event->flyer_image_url = $filename;
             $event->save();
@@ -966,7 +966,7 @@ class EventController extends Controller
             $file = new \Illuminate\Http\UploadedFile($request->social_image, basename($request->social_image));
             $filename = strtolower('flyer_' . Str::random(32)) . '.' . $file->getClientOriginalExtension();
             $disk = storage_public_disk();
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $event->flyer_image_url = $filename;
             $event->save();

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -50,7 +50,7 @@ class ProfileController extends Controller
 
             $file = $request->file('profile_image');
             $filename = strtolower('profile_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $user->profile_image_url = $filename;
             $user->save();

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -1036,7 +1036,7 @@ class RoleController extends Controller
 
             $file = $request->file('profile_image');
             $filename = strtolower('profile_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $role->profile_image_url = $filename;
             $role->save();
@@ -1052,7 +1052,7 @@ class RoleController extends Controller
 
             $file = $request->file('header_image');
             $filename = strtolower('header_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $role->header_image_url = $filename;
             $role->save();
@@ -1071,7 +1071,7 @@ class RoleController extends Controller
 
             $file = $request->file('background_image_url');
             $filename = strtolower('background_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $role->background_image_url = $filename;
             $role->save();
@@ -1300,7 +1300,7 @@ class RoleController extends Controller
 
             $file = $request->file('profile_image');
             $filename = strtolower('profile_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $role->profile_image_url = $filename;
             $role->save();
@@ -1316,7 +1316,7 @@ class RoleController extends Controller
 
             $file = $request->file('header_image_url');
             $filename = strtolower('header_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $role->header_image_url = $filename;
             $role->save();
@@ -1335,7 +1335,7 @@ class RoleController extends Controller
 
             $file = $request->file('background_image_url');
             $filename = strtolower('background_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $role->background_image_url = $filename;
             $role->save();

--- a/app/Repos/EventRepo.php
+++ b/app/Repos/EventRepo.php
@@ -312,7 +312,7 @@ class EventRepo
 
             $file = $request->file('flyer_image');
             $filename = strtolower('flyer_' . Str::random(32) . '.' . $file->getClientOriginalExtension());
-            $file->storeAs('', $filename, $disk);
+            storage_put_file_as_public($disk, $file, $filename);
 
             $event->flyer_image_url = $filename;
             $event->save();

--- a/app/Utils/ImageUtils.php
+++ b/app/Utils/ImageUtils.php
@@ -120,7 +120,7 @@ class ImageUtils
         
         $file = new \Illuminate\Http\UploadedFile($tempFile, $filenamePrefix . '.' . $extension);
         $disk = storage_public_disk();
-        $file->storeAs('', $filename, $disk);
+        storage_put_file_as_public($disk, $file, $filename);
 
         return $filename;
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -240,6 +240,29 @@ if (!function_exists('storage_asset_url')) {
     }
 }
 
+if (!function_exists('storage_put_file_as_public')) {
+    /**
+     * Persist an uploaded file on the public disk with explicit public visibility.
+     */
+    function storage_put_file_as_public(string $disk, \Illuminate\Http\UploadedFile $file, string $filename, string $directory = ''): string
+    {
+        $directory = trim($directory, '/');
+
+        $path = \Illuminate\Support\Facades\Storage::disk($disk)->putFileAs(
+            $directory === '' ? '' : $directory,
+            $file,
+            $filename,
+            ['visibility' => 'public']
+        );
+
+        if (is_string($path) && $path !== '') {
+            return $path;
+        }
+
+        return ltrim(($directory !== '' ? $directory . '/' : '') . $filename, '/');
+    }
+}
+
 if (!function_exists('vite_manifest')) {
     /**
      * Load the built Vite manifest once per request.


### PR DESCRIPTION
## Summary
- add a helper that stores uploaded files with explicit public visibility
- update every public disk upload to use the helper so generated files remain readable by nginx

## Testing
- ❌ `./vendor/bin/phpunit --testsuite Feature` (fails: vendor/bin/phpunit not present in container)


------
https://chatgpt.com/codex/tasks/task_e_68f83fa10d80832eb448658a06dafc32