### PR TITLE
Fix beta bump logic and allow marking major releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
         options:
           - production
           - beta
+      major_release:
+        description: 'Mark this release as a major version'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -34,7 +39,14 @@ jobs:
 
       - name: Determine release version
         id: version
-        run: php scripts/bump-version.php "${{ github.event.inputs.channel }}"
+        run: |
+          MAJOR_FLAG=""
+
+          if [ "${{ github.event.inputs.major_release }}" = "true" ]; then
+            MAJOR_FLAG="--major"
+          fi
+
+          php scripts/bump-version.php "${{ github.event.inputs.channel }}" $MAJOR_FLAG
 
       - name: Persist bumped version
         run: |

--- a/tests/Unit/BumpVersionScriptTest.php
+++ b/tests/Unit/BumpVersionScriptTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../scripts/bump-version.php';
+
+class BumpVersionScriptTest extends TestCase
+{
+    public function testBetaReleaseFromProductionVersionAddsPatchAndSuffix(): void
+    {
+        $this->assertSame('2.1.1b', bumpVersion('2.1', 'beta'));
+    }
+
+    public function testSubsequentBetaReleaseIncrementsPatch(): void
+    {
+        $this->assertSame('2.1.2b', bumpVersion('2.1.1b', 'beta'));
+    }
+
+    public function testBetaReleaseFromPatchedProductionVersionIncrementsPatch(): void
+    {
+        $this->assertSame('2.1.4b', bumpVersion('2.1.3', 'beta'));
+    }
+
+    public function testProductionReleaseIncrementsMinor(): void
+    {
+        $this->assertSame('2.2', bumpVersion('2.1', 'production'));
+    }
+
+    public function testMajorProductionReleaseResetsMinorVersion(): void
+    {
+        $this->assertSame('3.0', bumpVersion('2.1', 'production', true));
+    }
+
+    public function testMajorBetaReleaseResetsAndAddsBetaSuffix(): void
+    {
+        $this->assertSame('3.0.1b', bumpVersion('2.1', 'beta', true));
+    }
+}


### PR DESCRIPTION
## Summary
- update the version bump script to support a --major flag and keep beta bumps on the same major and minor release
- expose a `major_release` workflow input so major releases can be marked from the build workflow
- add unit coverage for the bumpVersion helper behaviour

## Testing
- php -l scripts/bump-version.php
- php -l tests/Unit/BumpVersionScriptTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f865111234832e887a322c9cc40a98