### PR TITLE
Fix major beta release finalization logic

### DIFF
--- a/scripts/bump-version.php
+++ b/scripts/bump-version.php
@@ -136,7 +136,7 @@ function bumpVersion(string $currentVersion, string $channel, bool $forceMajor =
         $nextMajor = $parsed['major'] + 1;
 
         if ($channel === 'beta') {
-            return formatVersion($nextMajor, 0, 1, 'b');
+            return formatVersion($nextMajor, 0, null, 'b');
         }
 
         return formatVersion($nextMajor, 0, null, null);
@@ -163,6 +163,15 @@ function bumpVersion(string $currentVersion, string $channel, bool $forceMajor =
     }
 
     // Production channel
+    if ($parsed['suffix'] !== null) {
+        return formatVersion(
+            $parsed['major'],
+            $parsed['minor'],
+            $parsed['patch'],
+            null
+        );
+    }
+
     $nextMinor = $parsed['minor'] + 1;
 
     return formatVersion($parsed['major'], $nextMinor, null, null);

--- a/tests/Unit/BumpVersionScriptTest.php
+++ b/tests/Unit/BumpVersionScriptTest.php
@@ -37,6 +37,16 @@ class BumpVersionScriptTest extends TestCase
 
     public function testMajorBetaReleaseResetsAndAddsBetaSuffix(): void
     {
-        $this->assertSame('3.0.1b', bumpVersion('2.1', 'beta', true));
+        $this->assertSame('3.0b', bumpVersion('2.1', 'beta', true));
+    }
+
+    public function testProductionReleaseFromBetaFinalizesVersion(): void
+    {
+        $this->assertSame('2.1.4', bumpVersion('2.1.4b', 'production'));
+    }
+
+    public function testProductionReleaseFromMajorBetaFinalizesVersion(): void
+    {
+        $this->assertSame('3.0', bumpVersion('3.0b', 'production'));
     }
 }


### PR DESCRIPTION
## Summary
- ensure forced-major beta releases reset the patch number and only add the beta suffix
- finalize production releases that follow beta builds without incrementing the minor version
- extend the bump version tests to cover the new production finalization behavior

## Testing
- ⚠️ `composer install` *(fails: GitHub API 403 while downloading symfony/finder without token)*

------
https://chatgpt.com/codex/tasks/task_e_68f8697b4314832ebe7e746437ffac26