### PR TITLE
Fix flyer image validation for event uploads

### DIFF
--- a/app/Http/Requests/EventCreateRequest.php
+++ b/app/Http/Requests/EventCreateRequest.php
@@ -16,7 +16,7 @@ class EventCreateRequest extends FormRequest
     public function rules(): array
     {        
         return [
-            'flyer_image_url' => ['image', 'max:2500'],
+            'flyer_image' => ['nullable', 'image', 'max:2500'],
             'slug' => ['nullable', 'string', 'max:255'],
         ];
     }

--- a/app/Http/Requests/EventUpdateRequest.php
+++ b/app/Http/Requests/EventUpdateRequest.php
@@ -16,7 +16,7 @@ class EventUpdateRequest extends FormRequest
     public function rules(): array
     {        
         return [
-            'flyer_image_url' => ['image', 'max:2500'],
+            'flyer_image' => ['nullable', 'image', 'max:2500'],
             'slug' => ['nullable', 'string', 'max:255'],
         ];
     }


### PR DESCRIPTION
## Summary
- validate flyer image uploads against the actual `flyer_image` field when creating or updating events
- allow flyer uploads to remain optional while enforcing the existing size limit

## Testing
- php artisan test *(fails: vendor/autoload.php missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8df2b4b78832eb950f3692cc4476a