### PR TITLE
Regenerate package-lock for cropperjs dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "name": "eventschedule",
             "dependencies": {
+                "cropperjs": "^1.6.1",
                 "easymde": "^2.18.0",
                 "flatpickr": "^4.6.13",
                 "toastify-js": "^1.12.0",
@@ -1270,6 +1271,12 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/cropperjs": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.1.tgz",
+            "integrity": "sha512-u6TPoPY1CkS7Z1xXLSM+UMtO4Okzp1KimG1Hj6kUMlzUxr87hcPLZ9eczsQnUnxE27XGr0C+MEY0S8NxV+4CSw==",
+            "license": "MIT"
         },
         "node_modules/chokidar": {
             "version": "3.6.0",


### PR DESCRIPTION
## Summary
- add cropperjs to the root dependency set in the lockfile
- lock cropperjs 1.6.1 metadata so npm installs stay in sync with package.json

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f91a4ea7d8832eb69f994cf336ea04