### PR TITLE
Fix cropperjs package integrity mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1275,7 +1275,7 @@
         "node_modules/cropperjs": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.6.1.tgz",
-            "integrity": "sha512-u6TPoPY1CkS7Z1xXLSM+UMtO4Okzp1KimG1Hj6kUMlzUxr87hcPLZ9eczsQnUnxE27XGr0C+MEY0S8NxV+4CSw==",
+            "integrity": "sha512-F4wsi+XkDHCOMrHMYjrTEE4QBOrsHHN5/2VsVAaRq8P7E5z7xQpT75S+f/9WikmBEailas3+yo+6zPIomW+NOA==",
             "license": "MIT"
         },
         "node_modules/chokidar": {


### PR DESCRIPTION
## Summary
- update the cropperjs integrity hash in package-lock.json so the registry checksum matches the published tarball

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-vue in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f920513058832e93e0de2f230e07e7