### PR TITLE
Fix localized ticket start date handling for UTC sale dates

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -670,7 +670,12 @@ class Event extends Model
 
         if ($date) {
             try {
-                $customDate = Carbon::createFromFormat('Y-m-d', $date);
+                $customDate = Carbon::createFromFormat('Y-m-d', $date, 'UTC');
+
+                if ($locale) {
+                    $customDate->setTimezone($startAt->getTimezone());
+                }
+
                 $startAt->setDate($customDate->year, $customDate->month, $customDate->day);
             } catch (\Exception $exception) {
                 // If the provided date is invalid, return null to indicate no valid start time

--- a/tests/Unit/EventStartDateTimeTest.php
+++ b/tests/Unit/EventStartDateTimeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Event;
+use App\Models\Role;
+use Tests\TestCase;
+
+class EventStartDateTimeTest extends TestCase
+{
+    public function test_localized_start_uses_converted_event_date()
+    {
+        $event = new Event([
+            'starts_at' => '2024-06-02 00:00:00',
+        ]);
+
+        $event->setRelation('creatorRole', new Role([
+            'timezone' => 'America/New_York',
+        ]));
+
+        $start = $event->getStartDateTime('2024-06-02', true);
+
+        $this->assertSame('America/New_York', $start->getTimezone()->getName());
+        $this->assertSame('2024-06-01 20:00:00', $start->format('Y-m-d H:i:s'));
+    }
+
+    public function test_custom_event_date_respects_local_timezone_shift()
+    {
+        $event = new Event([
+            'starts_at' => '2024-06-02 00:00:00',
+        ]);
+
+        $event->setRelation('creatorRole', new Role([
+            'timezone' => 'America/New_York',
+        ]));
+
+        $start = $event->getStartDateTime('2024-06-04', true);
+
+        $this->assertSame('2024-06-03', $start->format('Y-m-d'));
+        $this->assertSame('America/New_York', $start->getTimezone()->getName());
+    }
+}


### PR DESCRIPTION
## Summary
- adjust `Event::getStartDateTime` to convert UTC sale dates into the localized timezone before overriding the date
- add unit coverage to ensure localized start times respect the timezone shift when dates are stored in UTC

## Testing
- ⚠️ `./vendor/bin/phpunit --filter EventStartDateTimeTest` *(fails: vendor/bin/phpunit not found in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68f9200d3d2c832e88a830c3de86b937