### PR TITLE
Fix localized start date parsing for pre-localized input

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -647,8 +647,10 @@ class Event extends Model
                 return null;
             }
 
+            $dateTimezone = $locale ? $timezone : 'UTC';
+
             try {
-                $startAt = Carbon::createFromFormat('Y-m-d H:i:s', $date . ' 00:00:00', 'UTC');
+                $startAt = Carbon::createFromFormat('Y-m-d H:i:s', $date . ' 00:00:00', $dateTimezone);
             } catch (\Exception $exception) {
                 return null;
             }
@@ -670,11 +672,9 @@ class Event extends Model
 
         if ($date) {
             try {
-                $customDate = Carbon::createFromFormat('Y-m-d', $date, 'UTC');
-
-                if ($locale) {
-                    $customDate->setTimezone($startAt->getTimezone());
-                }
+                $customDateTimezone = $locale ? $startAt->getTimezone() : 'UTC';
+                $customDate = Carbon::createFromFormat('Y-m-d', $date, $customDateTimezone);
+                $customDate->setTimezone($startAt->getTimezone());
 
                 $startAt->setDate($customDate->year, $customDate->month, $customDate->day);
             } catch (\Exception $exception) {

--- a/tests/Unit/EventStartDateTimeTest.php
+++ b/tests/Unit/EventStartDateTimeTest.php
@@ -36,7 +36,8 @@ class EventStartDateTimeTest extends TestCase
 
         $start = $event->getStartDateTime('2024-06-04', true);
 
-        $this->assertSame('2024-06-03', $start->format('Y-m-d'));
+        $this->assertSame('2024-06-04', $start->format('Y-m-d'));
         $this->assertSame('America/New_York', $start->getTimezone()->getName());
+        $this->assertSame('2024-06-05 00:00:00', $start->copy()->setTimezone('UTC')->format('Y-m-d H:i:s'));
     }
 }


### PR DESCRIPTION
## Summary
- ensure getStartDateTime treats provided dates as localized when the caller requests localized output
- adjust unit coverage to match the corrected localized date handling

## Testing
- composer install --no-interaction *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f94c2b24d8832eb0655d669c1e09c1