### PR TITLE
Fix missing SquareImage import in role update request

### DIFF
--- a/app/Http/Requests/RoleUpdateRequest.php
+++ b/app/Http/Requests/RoleUpdateRequest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use App\Utils\UrlUtils;
 use App\Rules\NoFakeEmail;
+use App\Rules\SquareImage;
 
 class RoleUpdateRequest extends FormRequest
 {


### PR DESCRIPTION
## Summary
- import the SquareImage validation rule in RoleUpdateRequest so the form request can resolve properly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f959997af8832ea6c85aaab05858f1