### PR TITLE
Fix blank event form by exposing flatpickr globally

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,10 @@ Alpine.start();
 import flatpickr from 'flatpickr';
 import 'flatpickr/dist/flatpickr.css';
 
+// Expose flatpickr globally for legacy inline scripts that expect a global
+// reference (e.g. event create/edit pages initialising date pickers).
+window.flatpickr = flatpickr;
+
 //import Toastify from 'toastify-js';
 //import 'toastify-js/src/toastify.css';
 


### PR DESCRIPTION
## Summary
- expose flatpickr on the window object so legacy inline scripts can initialize datepickers on event forms

## Testing
- npm run build *(fails: vite not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f95cdb1b28832ebe4345d6ff7d0746