### PR TITLE
Guard venue id binding when no venue selected

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -213,7 +213,7 @@
                             </fieldset>
                         </div>
 
-                        <x-text-input name="venue_id" v-bind:value="selectedVenue.id" type="hidden" />
+                        <x-text-input name="venue_id" v-bind:value="selectedVenue ? selectedVenue.id : ''" type="hidden" />
 
                         <div :class="{ 'hidden': !(isInPerson || shouldBypassPreferences) }">
                             <div class="mb-6" :class="{ 'hidden': !shouldShowVenueForm }">


### PR DESCRIPTION
## Summary
- avoid dereferencing the selected venue when none is chosen on the event edit form to prevent Vue runtime errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f95f4eff10832ead6be9b0ca341184