### PR TITLE
Guard image library lists against invalid entries

### DIFF
--- a/resources/js/admin/image-library/components/ImageGrid.vue
+++ b/resources/js/admin/image-library/components/ImageGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
     <div
-      v-for="image in images"
+      v-for="image in safeImages"
       :key="image.id"
       class="rounded-lg border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-md"
       :class="{ 'ring-2 ring-indigo-500': selectedId === image.id }"
@@ -57,14 +57,16 @@
         </div>
       </div>
     </div>
-    <div v-if="!images.length" class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-8 text-center text-sm text-slate-500">
+    <div v-if="!safeImages.length" class="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-8 text-center text-sm text-slate-500">
       No images match the current filters.
     </div>
   </div>
 </template>
 
 <script setup>
-defineProps({
+import { computed } from 'vue';
+
+const props = defineProps({
   images: { type: Array, default: () => [] },
   selectable: { type: Boolean, default: false },
   selectedId: { type: [String, Number], default: null },
@@ -73,6 +75,14 @@ defineProps({
 });
 
 const emit = defineEmits(['select', 'replace', 'delete']);
+
+const safeImages = computed(() => {
+  if (!Array.isArray(props.images)) {
+    return [];
+  }
+
+  return props.images.filter((image) => image && typeof image === 'object' && image.id !== undefined && image.id !== null);
+});
 
 const onReplace = (image, event) => {
   const [file] = event.target.files || [];

--- a/resources/js/admin/image-library/components/ImageList.vue
+++ b/resources/js/admin/image-library/components/ImageList.vue
@@ -10,7 +10,7 @@
         </tr>
       </thead>
       <tbody class="divide-y divide-slate-100">
-        <tr v-for="image in images" :key="image.id" class="hover:bg-slate-50">
+        <tr v-for="image in safeImages" :key="image.id" class="hover:bg-slate-50">
           <td class="px-4 py-3">
             <div class="h-20 w-20 overflow-hidden rounded border border-slate-200">
               <img :src="image.url" :alt="image.display_name" class="h-full w-full object-cover" />
@@ -52,7 +52,7 @@
             </div>
           </td>
         </tr>
-        <tr v-if="!images.length">
+        <tr v-if="!safeImages.length">
           <td colspan="4" class="px-6 py-10 text-center text-sm text-slate-500">
             No images found. Try adjusting your search or filters.
           </td>
@@ -63,7 +63,9 @@
 </template>
 
 <script setup>
-defineProps({
+import { computed } from 'vue';
+
+const props = defineProps({
   images: { type: Array, default: () => [] },
   selectable: { type: Boolean, default: false },
   selectedId: { type: [String, Number], default: null },
@@ -72,6 +74,14 @@ defineProps({
 });
 
 const emit = defineEmits(['select', 'replace', 'delete']);
+
+const safeImages = computed(() => {
+  if (!Array.isArray(props.images)) {
+    return [];
+  }
+
+  return props.images.filter((image) => image && typeof image === 'object' && image.id !== undefined && image.id !== null);
+});
 
 const onReplace = (image, event) => {
   const [file] = event.target.files || [];


### PR DESCRIPTION
## Summary
- filter image grid and list data to only render valid image objects
- avoid rendering errors by basing empty states on the validated image collection

## Testing
- npm run build *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f98ed5108c832e9e9ea28cb2b04164