### PR TITLE
Normalize legacy storage paths before streaming

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -177,10 +177,20 @@ if (!function_exists('storage_normalize_path')) {
             return '';
         }
 
-        $normalized = ltrim($path, '/');
+        $normalized = str_replace('\\', '/', $path);
+
+        $normalized = ltrim($normalized, '/');
 
         while (str_starts_with($normalized, 'storage/')) {
             $normalized = ltrim(substr($normalized, strlen('storage/')), '/');
+        }
+
+        if ($normalized === 'app/public') {
+            return 'public';
+        }
+
+        if (str_starts_with($normalized, 'app/public/')) {
+            return substr($normalized, strlen('app/'));
         }
 
         return $normalized;

--- a/tests/Unit/StoragePathHelpersTest.php
+++ b/tests/Unit/StoragePathHelpersTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class StoragePathHelpersTest extends TestCase
+{
+    public function test_it_strips_leading_storage_prefixes(): void
+    {
+        $this->assertSame('file.png', storage_normalize_path('storage/file.png'));
+        $this->assertSame('file.png', storage_normalize_path('storage/storage/file.png'));
+    }
+
+    public function test_it_preserves_public_directory_prefix(): void
+    {
+        $this->assertSame('public/avatar.jpg', storage_normalize_path('public/avatar.jpg'));
+        $this->assertSame('public/avatar.jpg', storage_normalize_path('storage/public/avatar.jpg'));
+    }
+
+    public function test_it_converts_legacy_app_public_paths(): void
+    {
+        $this->assertSame('public/banner.png', storage_normalize_path('app/public/banner.png'));
+        $this->assertSame('public/banner.png', storage_normalize_path('storage/app/public/banner.png'));
+        $this->assertSame('public/banner.png', storage_normalize_path('storage/storage/app/public/banner.png'));
+        $this->assertSame('public', storage_normalize_path('app/public'));
+        $this->assertSame('public', storage_normalize_path('storage/app/public'));
+    }
+
+    public function test_it_normalizes_backslashes(): void
+    {
+        $this->assertSame('public/image.gif', storage_normalize_path('storage\\app\\public\\image.gif'));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize incoming storage paths by stripping legacy `app/public` prefixes and normalizing slashes before streaming files
- add unit coverage around the storage path helper to lock in the expected normalization behavior

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php because composer install requires GitHub access and returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f997644af4832e9728bbf416e26c8c