### PR TITLE
Ensure ColorUtils provides bundled background options

### DIFF
--- a/app/Utils/ColorUtils.php
+++ b/app/Utils/ColorUtils.php
@@ -76,9 +76,9 @@ class ColorUtils
         return $values[$random];
     }
 
-    public static function randomBackgroundImage()
+    public static function randomBackgroundImage(): string
     {
-        $options = array_keys(self::STATIC_BACKGROUND_IMAGES);
+        $options = array_keys(self::backgroundImageOptions());
 
         if (empty($options)) {
             return '';
@@ -87,8 +87,30 @@ class ColorUtils
         return $options[array_rand($options)];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function backgroundImageOptions(): array
     {
+        $paths = glob(public_path('images/backgrounds/*.png')) ?: [];
+        $options = [];
+
+        foreach ($paths as $path) {
+            $name = pathinfo($path, PATHINFO_FILENAME);
+
+            if (! is_string($name) || $name === '') {
+                continue;
+            }
+
+            $options[$name] = str_replace('_', ' ', $name);
+        }
+
+        if (! empty($options)) {
+            ksort($options, SORT_NATURAL | SORT_FLAG_CASE);
+
+            return $options;
+        }
+
         return self::STATIC_BACKGROUND_IMAGES;
     }
 


### PR DESCRIPTION
## Summary
- update `ColorUtils::backgroundImageOptions()` to enumerate bundled background image files and fall back to the legacy static list when none are present
- reuse the background image options when selecting a random background image so the list stays in sync

## Testing
- php -l app/Utils/ColorUtils.php


------
https://chatgpt.com/codex/tasks/task_e_68fa51a81c74832e85f775a51d89f533