### PR TITLE
Guard background image option lookup from missing helper

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -3024,9 +3024,11 @@ class RoleController extends Controller
     {
         static $hasLoggedFallback = false;
 
-        if (is_callable([ColorUtils::class, 'backgroundImageOptions'])) {
+        $backgroundImageOptionsCallable = [ColorUtils::class, 'backgroundImageOptions'];
+
+        if (method_exists(ColorUtils::class, 'backgroundImageOptions') && is_callable($backgroundImageOptionsCallable)) {
             try {
-                $options = ColorUtils::backgroundImageOptions();
+                $options = call_user_func($backgroundImageOptionsCallable);
 
                 if (is_array($options)) {
                     return $options;


### PR DESCRIPTION
## Summary
- ensure the role controller verifies `ColorUtils::backgroundImageOptions` exists before invoking it
- call the helper through `call_user_func` so older builds without the method fall back cleanly

## Testing
- not run (composer install blocked by network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68fa55992020832e9712648558441b68