### PR TITLE
Improve background image option fallback handling

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -3024,11 +3024,9 @@ class RoleController extends Controller
     {
         static $hasLoggedFallback = false;
 
-        $backgroundImageOptionsCallable = [ColorUtils::class, 'backgroundImageOptions'];
-
-        if (method_exists(ColorUtils::class, 'backgroundImageOptions') && is_callable($backgroundImageOptionsCallable)) {
-            try {
-                $options = call_user_func($backgroundImageOptionsCallable);
+        try {
+            if (method_exists(ColorUtils::class, 'backgroundImageOptions')) {
+                $options = ColorUtils::backgroundImageOptions();
 
                 if (is_array($options)) {
                     return $options;
@@ -3038,17 +3036,17 @@ class RoleController extends Controller
                     Log::warning('ColorUtils::backgroundImageOptions did not return an array. Falling back to bundled assets.');
                     $hasLoggedFallback = true;
                 }
-            } catch (\Throwable $exception) {
-                if (! $hasLoggedFallback) {
-                    Log::warning('ColorUtils::backgroundImageOptions threw an exception. Falling back to bundled assets.', [
-                        'exception' => $exception,
-                    ]);
-                    $hasLoggedFallback = true;
-                }
+            } elseif (! $hasLoggedFallback) {
+                Log::warning('ColorUtils::backgroundImageOptions is unavailable. Falling back to bundled assets.');
+                $hasLoggedFallback = true;
             }
-        } elseif (! $hasLoggedFallback) {
-            Log::warning('ColorUtils::backgroundImageOptions is unavailable. Falling back to bundled assets.');
-            $hasLoggedFallback = true;
+        } catch (\Throwable $exception) {
+            if (! $hasLoggedFallback) {
+                Log::warning('ColorUtils::backgroundImageOptions threw an exception. Falling back to bundled assets.', [
+                    'exception' => $exception,
+                ]);
+                $hasLoggedFallback = true;
+            }
         }
 
         $paths = glob(public_path('images/backgrounds/*.png')) ?: [];


### PR DESCRIPTION
## Summary
- wrap the ColorUtils background image option call in RoleController with a try/catch guard
- log clear fallback reasons and continue with bundled assets when the helper is missing or fails

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa5fc01c18832ea41b0a95b5a5e8a6