### PR TITLE
Improve background image option fallback handling

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -3024,9 +3024,11 @@ class RoleController extends Controller
     {
         static $hasLoggedFallback = false;
 
+        $callable = [ColorUtils::class, 'backgroundImageOptions'];
+
         try {
-            if (method_exists(ColorUtils::class, 'backgroundImageOptions')) {
-                $options = ColorUtils::backgroundImageOptions();
+            if (is_callable($callable)) {
+                $options = call_user_func($callable);
 
                 if (is_array($options)) {
                     return $options;


### PR DESCRIPTION
## Summary
- guard the background image option lookup in `RoleController` with `is_callable`
- invoke the utility method via `call_user_func` to avoid fatal errors when the method is missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa67294eac832eb77e35d792410633