### PR TITLE
Handle missing background image options gracefully

### DIFF
--- a/app/Utils/ColorUtils.php
+++ b/app/Utils/ColorUtils.php
@@ -78,7 +78,31 @@ class ColorUtils
 
     public static function randomBackgroundImage(): string
     {
-        $options = array_keys(self::backgroundImageOptions());
+        $options = [];
+
+        if (method_exists(static::class, 'backgroundImageOptions')) {
+            try {
+                $options = call_user_func([static::class, 'backgroundImageOptions']);
+            } catch (\Throwable $exception) {
+                $options = [];
+            }
+
+            if (! is_array($options)) {
+                $options = [];
+            }
+        }
+
+        if (empty($options)) {
+            $options = self::buildBundledBackgroundImageOptions();
+
+            if (empty($options)) {
+                $options = array_keys(self::STATIC_BACKGROUND_IMAGES);
+            } else {
+                $options = array_keys($options);
+            }
+        } else {
+            $options = array_keys($options);
+        }
 
         if (empty($options)) {
             return '';
@@ -91,6 +115,20 @@ class ColorUtils
      * @return array<string, string>
      */
     public static function backgroundImageOptions(): array
+    {
+        $options = self::buildBundledBackgroundImageOptions();
+
+        if (! empty($options)) {
+            return $options;
+        }
+
+        return self::STATIC_BACKGROUND_IMAGES;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function buildBundledBackgroundImageOptions(): array
     {
         $paths = glob(public_path('images/backgrounds/*.png')) ?: [];
         $options = [];
@@ -107,11 +145,9 @@ class ColorUtils
 
         if (! empty($options)) {
             ksort($options, SORT_NATURAL | SORT_FLAG_CASE);
-
-            return $options;
         }
 
-        return self::STATIC_BACKGROUND_IMAGES;
+        return $options;
     }
 
     /**

--- a/tests/Unit/ColorUtilsTest.php
+++ b/tests/Unit/ColorUtilsTest.php
@@ -81,4 +81,31 @@ class ColorUtilsTest extends TestCase
             $this->assertSame(str_replace('_', ' ', $name), $label);
         }
     }
+
+    public function testRandomBackgroundImageFallsBackGracefully(): void
+    {
+        $class = new class extends ColorUtils {
+            public static bool $shouldThrow = true;
+
+            public static function backgroundImageOptions(): array
+            {
+                if (self::$shouldThrow) {
+                    throw new \RuntimeException('boom');
+                }
+
+                return [];
+            }
+        };
+
+        $fqcn = get_class($class);
+        $result = $fqcn::randomBackgroundImage();
+
+        $this->assertNotSame('', $result);
+
+        $expectedOptions = array_keys(ColorUtils::backgroundImageOptions());
+        $staticOptions = array_keys((new \ReflectionClass(ColorUtils::class))->getConstant('STATIC_BACKGROUND_IMAGES'));
+        $combined = array_unique(array_merge($expectedOptions, $staticOptions));
+
+        $this->assertContains($result, $combined);
+    }
 }


### PR DESCRIPTION
## Summary
- harden ColorUtils::randomBackgroundImage to survive missing helpers and invalid option data
- centralize bundled background option discovery for reuse
- add a regression test covering the fallback behaviour

## Testing
- `./vendor/bin/phpunit --filter ColorUtilsTest` *(fails: vendor binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa6d3fa864832e803e1dbea6d73025