### PR TITLE
Respect configured URL scheme for forced HTTPS

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -60,10 +60,6 @@ class AppServiceProvider extends ServiceProvider
             Artisan::call('key:generate', ['--force' => true]);
         }
 
-        if (config('app.env') !== 'local') {
-            URL::forceScheme('https');
-        }
-
         $this->app->singleton('userRoles', function () {
             if ($user = auth()->user()) {
                 return $user->roles()->get();
@@ -122,6 +118,14 @@ class AppServiceProvider extends ServiceProvider
 
             if (!empty($googleWalletSettings)) {
                 WalletConfigManager::applyGoogle($googleWalletSettings);
+            }
+        }
+
+        if (config('app.env') !== 'local') {
+            $appUrl = config('app.url');
+
+            if (is_string($appUrl) && parse_url($appUrl, PHP_URL_SCHEME) === 'https') {
+                URL::forceScheme('https');
             }
         }
     }


### PR DESCRIPTION
## Summary
- update the application service provider to only force HTTPS when the configured app URL uses the https scheme
- ensure non-HTTPS configurations retain their original protocol

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa79a192d4832e8096ffa8392381a8