### PR TITLE
Fix media picker initialization on edit screens

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,8 @@
 import './bootstrap';
 
 import Alpine from 'alpinejs';
+import './media-picker';
+
 window.Alpine = Alpine;
 Alpine.start();
 
@@ -16,8 +18,6 @@ window.flatpickr = flatpickr;
 
 import EasyMDE from 'easymde';
 import 'easymde/dist/easymde.min.css';
-import './media-picker';
-
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.html-editor').forEach(element => {
         const easyMDE = new EasyMDE({


### PR DESCRIPTION
## Summary
- ensure the media picker Alpine component is registered before Alpine starts so edit modals work again

## Testing
- npm run build *(fails: vite not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa81b5db30832e9c3fb77cc89c7a4d