### PR TITLE
Ensure media picker initializes reliably on edit forms

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,8 @@
 import './bootstrap';
 
 import Alpine from 'alpinejs';
+import './media-picker';
+
 window.Alpine = Alpine;
 Alpine.start();
 
@@ -16,8 +18,6 @@ window.flatpickr = flatpickr;
 
 import EasyMDE from 'easymde';
 import 'easymde/dist/easymde.min.css';
-import './media-picker';
-
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.html-editor').forEach(element => {
         const easyMDE = new EasyMDE({

--- a/resources/js/media-picker.js
+++ b/resources/js/media-picker.js
@@ -9,12 +9,19 @@ const csrfToken = () => {
 
 const buildHeaders = (extra = {}) => ({
     'X-CSRF-TOKEN': csrfToken(),
+    'X-Requested-With': 'XMLHttpRequest',
     Accept: 'application/json',
     ...extra,
 });
 
-document.addEventListener('alpine:init', () => {
-    Alpine.data('mediaLibraryPage', (config) => ({
+const registerMediaLibraryComponents = (alpineInstance) => {
+    if (!alpineInstance || registerMediaLibraryComponents.registered) {
+        return;
+    }
+
+    registerMediaLibraryComponents.registered = true;
+
+    alpineInstance.data('mediaLibraryPage', (config) => ({
         assets: [],
         tags: [],
         pagination: {
@@ -226,7 +233,7 @@ document.addEventListener('alpine:init', () => {
         },
     }));
 
-    Alpine.data('mediaPicker', (config) => ({
+    alpineInstance.data('mediaPicker', (config) => ({
         assets: [],
         tags: [],
         pagination: {
@@ -423,6 +430,9 @@ document.addEventListener('alpine:init', () => {
 
             const formData = new FormData();
             formData.append('file', file);
+            if (config.context) {
+                formData.append('context', config.context);
+            }
 
             try {
                 const response = await fetch(config.uploadEndpoint, {
@@ -456,4 +466,12 @@ document.addEventListener('alpine:init', () => {
             return asset.original_filename || 'Asset';
         },
     }));
-});
+};
+
+if (window.Alpine) {
+    registerMediaLibraryComponents(window.Alpine);
+} else {
+    document.addEventListener('alpine:init', () => {
+        registerMediaLibraryComponents(window.Alpine || Alpine);
+    });
+}


### PR DESCRIPTION
## Summary
- register the media picker Alpine data even if Alpine has already started
- include the XMLHttpRequest header and optional context when uploading from the picker

## Testing
- npm run build *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fa81b5db30832e9c3fb77cc89c7a4d