### PR TITLE
Stabilize media picker registration and authenticated uploads

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,7 +1,10 @@
 import './bootstrap';
 
 import Alpine from 'alpinejs';
+import { registerMediaLibraryComponents } from './media-picker';
+
 window.Alpine = Alpine;
+registerMediaLibraryComponents(Alpine);
 Alpine.start();
 
 import flatpickr from 'flatpickr';
@@ -16,8 +19,6 @@ window.flatpickr = flatpickr;
 
 import EasyMDE from 'easymde';
 import 'easymde/dist/easymde.min.css';
-import './media-picker';
-
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.html-editor').forEach(element => {
         const easyMDE = new EasyMDE({


### PR DESCRIPTION
## Summary
- export a helper to register the media picker components and invoke it before Alpine boots
- keep a safety listener for late Alpine initialisation while avoiding duplicate registrations
- include same-origin credentials on every media picker request so uploads succeed from edit screens

## Testing
- npm run build *(fails: vite not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa81b5db30832e9c3fb77cc89c7a4d