### PR TITLE
Use relative media library endpoints

### DIFF
--- a/resources/views/components/media-picker.blade.php
+++ b/resources/views/components/media-picker.blade.php
@@ -18,11 +18,11 @@
 
 <div
     x-data="mediaPicker({
-        assetsEndpoint: '{{ route('media.assets.index') }}',
-        uploadEndpoint: '{{ route('media.assets.store') }}',
-        tagsEndpoint: '{{ route('media.tags.index') }}',
-        createTagEndpoint: '{{ route('media.tags.store') }}',
-        variantEndpointTemplate: '{{ route('media.assets.variants.store', ['asset' => '__ASSET__']) }}',
+        assetsEndpoint: '{{ route('media.assets.index', [], false) }}',
+        uploadEndpoint: '{{ route('media.assets.store', [], false) }}',
+        tagsEndpoint: '{{ route('media.tags.index', [], false) }}',
+        createTagEndpoint: '{{ route('media.tags.store', [], false) }}',
+        variantEndpointTemplate: '{{ route('media.assets.variants.store', ['asset' => '__ASSET__'], false) }}',
         context: @json($context),
         initialAssetId: {{ $initialAsset ? (int) $initialAsset : 'null' }},
         initialVariantId: {{ $initialVariant ? (int) $initialVariant : 'null' }},

--- a/resources/views/media/index.blade.php
+++ b/resources/views/media/index.blade.php
@@ -5,11 +5,11 @@
 
     <div
         x-data="mediaLibraryPage({
-            assetsEndpoint: '{{ route('media.assets.index') }}',
-            uploadEndpoint: '{{ route('media.assets.store') }}',
-            tagsEndpoint: '{{ route('media.tags.index') }}',
-            createTagEndpoint: '{{ route('media.tags.store') }}',
-            syncTagsTemplate: '{{ route('media.assets.tags.sync', ['asset' => '__ID__']) }}',
+            assetsEndpoint: '{{ route('media.assets.index', [], false) }}',
+            uploadEndpoint: '{{ route('media.assets.store', [], false) }}',
+            tagsEndpoint: '{{ route('media.tags.index', [], false) }}',
+            createTagEndpoint: '{{ route('media.tags.store', [], false) }}',
+            syncTagsTemplate: '{{ route('media.assets.tags.sync', ['asset' => '__ID__'], false) }}',
         })"
         x-init="init()"
         class="space-y-6"


### PR DESCRIPTION
## Summary
- update the media picker component to use relative Media Library API routes
- align the standalone Media Library page with the same relative endpoints to avoid cross-origin calls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa8da06258832e9006efb2cc8b5375