### PR TITLE
Enable deleting media assets from the library

### DIFF
--- a/app/Http/Controllers/MediaLibraryController.php
+++ b/app/Http/Controllers/MediaLibraryController.php
@@ -144,6 +144,21 @@ class MediaLibraryController extends Controller
         ], 201);
     }
 
+    public function destroy(MediaAsset $asset): JsonResponse
+    {
+        if ($asset->usages()->exists()) {
+            return response()->json([
+                'message' => 'This asset is currently in use and cannot be deleted.',
+            ], 422);
+        }
+
+        $asset->delete();
+
+        return response()->json([
+            'success' => true,
+        ]);
+    }
+
     public function storeVariant(Request $request, MediaAsset $asset): JsonResponse
     {
         $validated = $request->validate([

--- a/app/Models/MediaAssetVariant.php
+++ b/app/Models/MediaAssetVariant.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
 
 class MediaAssetVariant extends Model
 {
@@ -27,6 +29,21 @@ class MediaAssetVariant extends Model
         'size' => 'integer',
         'crop_meta' => 'array',
     ];
+
+    protected static function booted(): void
+    {
+        static::deleting(function (MediaAssetVariant $variant): void {
+            $disk = $variant->disk ?: storage_public_disk();
+
+            if ($variant->path) {
+                try {
+                    Storage::disk($disk)->delete($variant->path);
+                } catch (Throwable $exception) {
+                    report($exception);
+                }
+            }
+        });
+    }
 
     public function asset(): BelongsTo
     {

--- a/resources/views/media/index.blade.php
+++ b/resources/views/media/index.blade.php
@@ -11,6 +11,7 @@
             createTagEndpoint: '{{ route('media.tags.store', [], false) }}',
             deleteTagTemplate: '{{ route('media.tags.destroy', ['tag' => '__ID__'], false) }}',
             syncTagsTemplate: '{{ route('media.assets.tags.sync', ['asset' => '__ID__'], false) }}',
+            deleteAssetTemplate: '{{ route('media.assets.destroy', ['asset' => '__ID__'], false) }}',
         })"
         x-init="init()"
         class="space-y-6"
@@ -104,6 +105,7 @@
                             <div class="mt-auto flex items-center gap-2 pt-2">
                                 <button type="button" class="text-sm text-indigo-600 hover:text-indigo-500" @click="openTagEditor(asset)">{{ __('Edit tags') }}</button>
                                 <button type="button" class="text-sm text-gray-600 dark:text-gray-300 hover:text-gray-500" @click="openDetails(asset)">{{ __('Details') }}</button>
+                                <button type="button" class="ml-auto text-sm text-red-600 hover:text-red-500" @click="deleteAsset(asset)">{{ __('Delete') }}</button>
                             </div>
                         </div>
                     </div>
@@ -214,6 +216,11 @@
                                     </div>
                                 </template>
                             </div>
+                        </div>
+                        <div>
+                            <button type="button" class="inline-flex items-center justify-center rounded-md border border-red-200 px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50" @click="deleteAsset(detailAsset)">
+                                {{ __('Delete asset') }}
+                            </button>
                         </div>
                     </div>
                 </template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -131,6 +131,9 @@ Route::middleware(['auth', 'verified'])->group(function ()
     Route::get('/media-library', [MediaLibraryController::class, 'index'])->name('media.index');
     Route::get('/media-library/assets', [MediaLibraryController::class, 'list'])->name('media.assets.index');
     Route::post('/media-library/assets', [MediaLibraryController::class, 'store'])->name('media.assets.store');
+    Route::delete('/media-library/assets/{asset}', [MediaLibraryController::class, 'destroy'])
+        ->whereNumber('asset')
+        ->name('media.assets.destroy');
     Route::post('/media-library/assets/{asset}/variants', [MediaLibraryController::class, 'storeVariant'])->name('media.assets.variants.store');
     Route::get('/media-library/tags', [MediaLibraryController::class, 'tags'])->name('media.tags.index');
     Route::post('/media-library/tags', [MediaLibraryController::class, 'storeTag'])->name('media.tags.store');

--- a/tests/Feature/MediaLibrary/MediaAssetDeletionTest.php
+++ b/tests/Feature/MediaLibrary/MediaAssetDeletionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\MediaLibrary;
+
+use App\Models\MediaAsset;
+use App\Models\MediaAssetUsage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class MediaAssetDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_delete_unused_asset(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $assetPath = 'media/test-image.jpg';
+        $variantPath = 'media/variants/test-image.jpg';
+
+        Storage::disk('public')->put($assetPath, 'asset');
+        Storage::disk('public')->put($variantPath, 'variant');
+
+        $asset = MediaAsset::create([
+            'disk' => 'public',
+            'path' => $assetPath,
+            'original_filename' => 'test-image.jpg',
+            'mime_type' => 'image/jpeg',
+            'size' => 1024,
+            'width' => 120,
+            'height' => 80,
+            'uploaded_by' => $user->id,
+        ]);
+
+        $variant = $asset->variants()->create([
+            'disk' => 'public',
+            'path' => $variantPath,
+            'label' => 'crop',
+            'width' => 60,
+            'height' => 40,
+            'size' => 512,
+        ]);
+
+        $response = $this->actingAs($user)->deleteJson(route('media.assets.destroy', ['asset' => $asset->id]));
+
+        $response->assertOk()->assertJson(['success' => true]);
+
+        $this->assertDatabaseMissing('media_assets', ['id' => $asset->id]);
+        $this->assertDatabaseMissing('media_asset_variants', ['id' => $variant->id]);
+        Storage::disk('public')->assertMissing($assetPath);
+        Storage::disk('public')->assertMissing($variantPath);
+    }
+
+    public function test_user_cannot_delete_asset_that_is_in_use(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $assetPath = 'media/used-image.jpg';
+        Storage::disk('public')->put($assetPath, 'asset');
+
+        $asset = MediaAsset::create([
+            'disk' => 'public',
+            'path' => $assetPath,
+            'original_filename' => 'used-image.jpg',
+            'mime_type' => 'image/jpeg',
+            'size' => 2048,
+            'width' => 200,
+            'height' => 100,
+            'uploaded_by' => $user->id,
+        ]);
+
+        MediaAssetUsage::create([
+            'media_asset_id' => $asset->id,
+            'media_asset_variant_id' => null,
+            'usable_type' => User::class,
+            'usable_id' => $user->id,
+            'context' => 'general',
+        ]);
+
+        $response = $this->actingAs($user)->deleteJson(route('media.assets.destroy', ['asset' => $asset->id]));
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'This asset is currently in use and cannot be deleted.',
+        ]);
+
+        $this->assertDatabaseHas('media_assets', ['id' => $asset->id]);
+        Storage::disk('public')->assertExists($assetPath);
+    }
+}


### PR DESCRIPTION
## Summary
- add an API endpoint to delete media assets after ensuring they are not in use
- remove stored files for assets and variants when records are deleted
- expose delete actions in the media library UI and adjust the Alpine component
- cover the new behaviour with feature tests

## Testing
- ⚠️ `composer install --no-interaction --no-progress` *(fails: network restrictions when cloning dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68fba05de914832e9a5ecc40e799112d