### PR TITLE
Allow clearing blog featured image

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -232,6 +232,10 @@ class BlogController extends Controller
                 return $request->string('featured_image')->trim()->value();
             }
 
+            if ($request->exists('featured_media_asset_id') || $request->exists('featured_image')) {
+                return null;
+            }
+
             return $default;
         }
 


### PR DESCRIPTION
## Summary
- ensure blog post featured images can be cleared when the picker submits empty values
- return null from resolveFeaturedImagePath when both featured_media_* fields are empty

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fbc2954220832e9904296d250872ef