### PR TITLE
Remove legacy image upload inputs from role and event forms

### DIFF
--- a/resources/js/media-picker.js
+++ b/resources/js/media-picker.js
@@ -580,6 +580,19 @@ class MediaPickerController {
         if (this.elements.variantInput) {
             this.elements.variantInput.value = this.selectedVariantId ? String(this.selectedVariantId) : '';
         }
+
+        const eventDetail = {
+            assetId: this.selectedAssetId,
+            variantId: this.selectedVariantId,
+            url: this.previewUrl || null,
+        };
+
+        this.root.dispatchEvent(
+            new CustomEvent('media-picker:change', {
+                bubbles: true,
+                detail: eventDetail,
+            }),
+        );
     }
 
     openModal() {

--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -706,9 +706,6 @@
                         
                         <div class="mb-6">
                             <x-input-label for="flyer_image" :value="__('messages.flyer_image')" />
-                            <input id="flyer_image" name="flyer_image" type="file" class="mt-1 block w-full text-gray-900 dark:text-gray-100"
-                                accept="image/png, image/jpeg" onchange="previewImage(this);" />
-                            <x-input-error class="mt-2" :messages="$errors->get('flyer_image')" />
                             <div class="mt-4">
                                 <x-media-picker
                                     name="flyer_media_variant_id"
@@ -717,13 +714,6 @@
                                     :initial-url="$event->flyer_image_url"
                                     label="{{ __('Choose from library') }}"
                                 />
-                            </div>
-                            <p id="image_size_warning" class="mt-2 text-sm text-red-600 dark:text-red-400" style="display: none;">
-                                {{ __('messages.image_size_warning') }}
-                            </p>
-
-                            <div id="image_preview" class="mt-3" style="display: none;">
-                                <img id="preview_img" src="#" alt="Preview" style="max-height:120px" />
                             </div>
 
                             @if ($event->flyer_image_url)


### PR DESCRIPTION
## Summary
- remove the legacy file-upload controls from the role profile, header, and background sections in favor of the media picker
- drop the raw flyer upload input on the event edit form so only the media picker is exposed
- emit a `media-picker:change` event from the media picker controller so existing preview logic can react to selection changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbdae02d00832eae6793e8d0c3ae50