### PR TITLE
Respect mail disable setting across notifications

### DIFF
--- a/app/Notifications/AddedMemberNotification.php
+++ b/app/Notifications/AddedMemberNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Support\MailConfigManager;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -32,6 +33,12 @@ class AddedMemberNotification extends Notification
      */
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         return ['mail'];
     }
 

--- a/app/Notifications/DeletedEventNotification.php
+++ b/app/Notifications/DeletedEventNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use App\Models\Event;
 use App\Models\Role;
 use App\Models\User;
+use App\Support\MailConfigManager;
 use App\Utils\NotificationUtils;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -29,6 +30,12 @@ class DeletedEventNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         return ['mail'];
     }
 

--- a/app/Notifications/DeletedRoleNotification.php
+++ b/app/Notifications/DeletedRoleNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Support\MailConfigManager;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -30,6 +31,12 @@ class DeletedRoleNotification extends Notification
      */
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         return ['mail'];
     }
 

--- a/app/Notifications/EventAddedNotification.php
+++ b/app/Notifications/EventAddedNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use App\Models\Event;
 use App\Models\Role;
 use App\Models\User;
+use App\Support\MailConfigManager;
 use App\Utils\NotificationUtils;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -29,6 +30,12 @@ class EventAddedNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         return ['mail'];
     }
 

--- a/app/Notifications/EventRequestNotification.php
+++ b/app/Notifications/EventRequestNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Support\MailConfigManager;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -30,6 +31,12 @@ class EventRequestNotification extends Notification
      */
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         return ['mail'];
     }
 

--- a/app/Notifications/RequestAcceptedNotification.php
+++ b/app/Notifications/RequestAcceptedNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use App\Models\Event;
 use App\Models\Role;
 use App\Models\User;
+use App\Support\MailConfigManager;
 use App\Utils\NotificationUtils;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -29,6 +30,12 @@ class RequestAcceptedNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         return ['mail'];
     }
 

--- a/app/Notifications/RequestDeclinedNotification.php
+++ b/app/Notifications/RequestDeclinedNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use App\Models\Event;
 use App\Models\Role;
 use App\Models\User;
+use App\Support\MailConfigManager;
 use App\Utils\NotificationUtils;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -29,6 +30,12 @@ class RequestDeclinedNotification extends Notification
 
     public function via(object $notifiable): array
     {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
         return ['mail'];
     }
 

--- a/app/Notifications/VerifyEmail.php
+++ b/app/Notifications/VerifyEmail.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use App\Support\MailConfigManager;
 use App\Utils\UrlUtils;
 use Illuminate\Auth\Notifications\VerifyEmail as BaseVerifyEmail;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -20,11 +21,22 @@ class VerifyEmail extends BaseVerifyEmail
     protected $notifiable;
 
     public function __construct($type = 'user', $subdomain = '')
-    {        
+    {
         $this->type = $type;
         $this->subdomain = $subdomain;
     }
-    
+
+    public function via($notifiable)
+    {
+        MailConfigManager::applyFromDatabase();
+
+        if (config('mail.disable_delivery')) {
+            return [];
+        }
+
+        return parent::via($notifiable);
+    }
+
     public function toMail($notifiable)
     {
         $this->notifiable = $notifiable;

--- a/tests/Feature/MailDisableDeliveryTest.php
+++ b/tests/Feature/MailDisableDeliveryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\Setting;
+use App\Models\User;
+use App\Notifications\EventAddedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MailDisableDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_event_added_notification_respects_mail_disable_setting(): void
+    {
+        config(['mail.disable_delivery' => false]);
+
+        $event = new Event();
+        $notifiable = User::factory()->create();
+
+        Setting::setGroup('mail', ['disable_delivery' => '0']);
+        $enabledNotification = new EventAddedNotification($event);
+        $this->assertSame(['mail'], $enabledNotification->via($notifiable));
+
+        Setting::setGroup('mail', ['disable_delivery' => '1']);
+        $disabledNotification = new EventAddedNotification($event);
+        $this->assertSame([], $disabledNotification->via($notifiable));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure team and event notifications re-apply mail settings and skip email delivery when it is disabled
- guard verification emails with the same setting
- add a feature test covering the EventAddedNotification mail-disable behaviour

## Testing
- ⚠️ `composer install --no-interaction --prefer-dist` *(fails: CONNECT tunnel failed while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68fbe8fd2c94832e896db34deaeb26cc