### PR TITLE
Fix sidebar navigation toggles

### DIFF
--- a/resources/views/layouts/app-admin.blade.php
+++ b/resources/views/layouts/app-admin.blade.php
@@ -13,10 +13,10 @@
                 function toggleMenu() {
                     const isOpen = sidebar.getAttribute('data-state') === 'open';
                     if (isOpen) {
-                        $('#sidebar').show();
+                        $('#sidebar').hide();
                         sidebar.setAttribute('data-state', 'closed');
                     } else {
-                        $('#sidebar').hide();
+                        $('#sidebar').show();
                         sidebar.setAttribute('data-state', 'open');
                     }
                 }
@@ -28,7 +28,13 @@
                     const $trigger = $(this);
                     const $container = $trigger.closest('[data-collapse-container]');
                     const contentId = $trigger.attr('aria-controls');
-                    const $content = contentId ? $('#' + contentId) : $();
+                    let $content = $container.find('[data-collapse-content]');
+
+                    if (contentId) {
+                        $content = $content.filter(function() {
+                            return $(this).attr('id') === contentId;
+                        });
+                    }
                     const $icon = $trigger.find('[data-collapse-icon]');
                     const initialOpen = $container.attr('data-collapse-state') === 'open';
 


### PR DESCRIPTION
## Summary
- correct the mobile sidebar toggle to open and close on the first click
- scope collapse button logic to the current navigation block so expand/collapse works reliably

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbec0ddaf8832eaad261165cb89aa6