### PR TITLE
Add system-aware dark mode with theme controls

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -5,3 +5,40 @@
 [x-cloak] {
     display: none !important;
 }
+
+@layer base {
+    :root {
+        color-scheme: light;
+        --color-surface: theme('colors.white');
+        --color-surface-muted: theme('colors.gray.100');
+        --color-border: theme('colors.gray.200');
+        --color-text-primary: theme('colors.gray.900');
+        --color-text-muted: theme('colors.gray.600');
+    }
+
+    .dark {
+        color-scheme: dark;
+        --color-surface: theme('colors.gray.900');
+        --color-surface-muted: theme('colors.gray.800');
+        --color-border: theme('colors.gray.700');
+        --color-text-primary: theme('colors.gray.100');
+        --color-text-muted: theme('colors.gray.400');
+    }
+
+    html {
+        @apply h-full;
+    }
+
+    body {
+        @apply min-h-full bg-gray-50 text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100;
+        color: var(--color-text-primary);
+    }
+
+    a {
+        @apply text-indigo-600 transition-colors duration-150 dark:text-indigo-400;
+    }
+
+    a:hover {
+        @apply text-indigo-500 dark:text-indigo-300;
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,149 @@ window.Alpine = Alpine;
 registerMediaLibraryComponents(Alpine);
 Alpine.start();
 
+const themeStorageKey = 'theme';
+const themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+const isValidTheme = (value) => ['light', 'dark', 'system'].includes(value);
+
+const getStoredThemePreference = () => {
+    const stored = window.localStorage.getItem(themeStorageKey);
+
+    if (isValidTheme(stored)) {
+        return stored;
+    }
+
+    return 'system';
+};
+
+let lastResolvedTheme = null;
+let lastThemePreference = null;
+
+const resolveTheme = (preference) => {
+    if (preference === 'system') {
+        return themeMediaQuery.matches ? 'dark' : 'light';
+    }
+
+    return preference;
+};
+
+const dispatchThemeChange = (preference, resolved) => {
+    document.dispatchEvent(new CustomEvent('theme:change', {
+        detail: {
+            preference,
+            resolved,
+        },
+    }));
+};
+
+const applyThemePreference = (preference, { notify = true } = {}) => {
+    const resolved = resolveTheme(preference);
+    const root = document.documentElement;
+
+    root.classList.toggle('dark', resolved === 'dark');
+    root.dataset.themePreference = preference;
+    root.dataset.themeResolved = resolved;
+    root.style.colorScheme = resolved;
+
+    if (notify && (preference !== lastThemePreference || resolved !== lastResolvedTheme)) {
+        dispatchThemeChange(preference, resolved);
+    }
+
+    lastThemePreference = preference;
+    lastResolvedTheme = resolved;
+};
+
+const setThemePreference = (preference) => {
+    if (!isValidTheme(preference)) {
+        return;
+    }
+
+    window.localStorage.setItem(themeStorageKey, preference);
+    applyThemePreference(preference);
+};
+
+const refreshThemePreference = () => {
+    applyThemePreference(getStoredThemePreference());
+};
+
+const getThemeSelects = () => Array.from(document.querySelectorAll('[data-theme-select]'));
+
+const syncThemeSelects = (preference = getStoredThemePreference()) => {
+    getThemeSelects().forEach((select) => {
+        if (select instanceof HTMLSelectElement) {
+            select.value = preference;
+        }
+    });
+};
+
+const bindThemeSelects = () => {
+    getThemeSelects().forEach((select) => {
+        if (!(select instanceof HTMLSelectElement)) {
+            return;
+        }
+
+        select.addEventListener('change', (event) => {
+            const target = event.target;
+
+            if (target instanceof HTMLSelectElement) {
+                setThemePreference(target.value);
+            }
+        });
+    });
+};
+
+const removeDuplicateFloatingSelectors = () => {
+    const selects = getThemeSelects();
+    const floatingSelects = selects.filter((select) => select.hasAttribute('data-theme-floating'));
+
+    if (floatingSelects.length && selects.length > floatingSelects.length) {
+        floatingSelects.forEach((select) => {
+            const wrapper = select.closest('[data-theme-floating-wrapper]');
+
+            if (wrapper) {
+                wrapper.remove();
+            } else {
+                select.remove();
+            }
+        });
+    }
+};
+
+if (!window.theme) {
+    window.theme = {};
+}
+
+window.theme.get = getStoredThemePreference;
+window.theme.set = setThemePreference;
+window.theme.apply = applyThemePreference;
+window.theme.refresh = refreshThemePreference;
+
+const handleSystemThemeChange = () => {
+    if (getStoredThemePreference() === 'system') {
+        applyThemePreference('system');
+    }
+};
+
+if (typeof themeMediaQuery.addEventListener === 'function') {
+    themeMediaQuery.addEventListener('change', handleSystemThemeChange);
+} else if (typeof themeMediaQuery.addListener === 'function') {
+    themeMediaQuery.addListener(handleSystemThemeChange);
+}
+
+window.addEventListener('storage', (event) => {
+    if (event.key === themeStorageKey) {
+        refreshThemePreference();
+    }
+});
+
+document.addEventListener('theme:change', (event) => {
+    const preference = event.detail?.preference;
+
+    if (isValidTheme(preference)) {
+        syncThemeSelects(preference);
+    }
+});
+
 const bootstrapPickers = () => initMediaPickers();
 
 if (document.readyState === 'loading') {
@@ -28,6 +171,11 @@ window.flatpickr = flatpickr;
 import EasyMDE from 'easymde';
 import 'easymde/dist/easymde.min.css';
 document.addEventListener('DOMContentLoaded', () => {
+    applyThemePreference(getStoredThemePreference(), { notify: false });
+    syncThemeSelects();
+    bindThemeSelects();
+    removeDuplicateFloatingSelectors();
+
     document.querySelectorAll('.html-editor').forEach(element => {
         const easyMDE = new EasyMDE({
             element: element,

--- a/resources/views/layouts/app-admin.blade.php
+++ b/resources/views/layouts/app-admin.blade.php
@@ -75,7 +75,7 @@
     <div>
         <!-- Off-canvas menu for mobile, show/hide based on off-canvas menu state. -->
         <div data-state="closed" id="sidebar" class="relative z-50 hidden" role="dialog" aria-modal="true">
-            <div class="fixed inset-0 bg-gray-900/80" aria-hidden="true"></div>
+            <div class="fixed inset-0 bg-gray-900/80 dark:bg-black/70" aria-hidden="true"></div>
 
             <div class="fixed inset-0 flex">
                 <div class="relative mr-16 flex w-full max-w-xs flex-1">
@@ -90,9 +90,9 @@
                     </div>
 
                     <!-- Sidebar component, swap this element with another sidebar if you like -->
-                    <div class="flex grow flex-col gap-y-5 overflow-y-auto bg-gray-900 px-6 pb-4 ring-1 ring-white/10">
+                    <div class="flex grow flex-col gap-y-5 overflow-y-auto bg-white px-6 pb-4 text-gray-900 ring-1 ring-black/10 dark:bg-gray-950 dark:text-gray-100 dark:ring-white/10">
 
-                        @include('layouts.navigation')                        
+                        @include('layouts.navigation')
 
                     </div>
                 </div>
@@ -102,7 +102,7 @@
         <!-- Static sidebar for desktop -->
         <div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
             <!-- Sidebar component, swap this element with another sidebar if you like -->
-            <div class="flex grow flex-col gap-y-5 overflow-y-auto bg-gray-900 px-6 pb-4">
+            <div class="flex grow flex-col gap-y-5 overflow-y-auto border-r border-gray-200 bg-white px-6 pb-4 dark:border-gray-800 dark:bg-gray-950">
 
                 @include('layouts.navigation')
 
@@ -111,8 +111,8 @@
 
         <div class="lg:pl-72 flex flex-col min-h-screen">
             <div
-                class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
-                <button id="open-sidebar" type="button" class="-m-2.5 p-2.5 text-gray-700 lg:hidden">
+                class="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b border-gray-200 bg-white px-4 shadow-sm transition-colors duration-200 dark:border-gray-800 dark:bg-gray-900 dark:shadow-black/30 sm:gap-x-6 sm:px-6 lg:px-8">
+                <button id="open-sidebar" type="button" class="-m-2.5 p-2.5 text-gray-700 transition-colors duration-150 hover:text-gray-900 lg:hidden dark:text-gray-200 dark:hover:text-gray-50">
                     <span class="sr-only">{{ __('messages.open_sidebar') }}</span>
                     <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
                         aria-hidden="true">
@@ -122,7 +122,7 @@
                 </button>
 
                 <!-- Separator -->
-                <div class="h-6 w-px bg-gray-900/10 lg:hidden" aria-hidden="true"></div>
+                <div class="h-6 w-px bg-gray-900/10 lg:hidden dark:bg-white/10" aria-hidden="true"></div>
 
                 <div class="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
                     <div class="relative flex flex-1"></div>
@@ -149,8 +149,18 @@
                         -->
 
                         <!-- Separator -->
-                        <div class="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10" aria-hidden="true"></div>
+                        <div class="hidden lg:block lg:h-6 lg:w-px lg:bg-gray-900/10 dark:lg:bg-white/10" aria-hidden="true"></div>
 
+
+                        <div class="flex items-center">
+                            <label for="theme-preference" class="sr-only">{{ __('Theme') }}</label>
+                            <select id="theme-preference" data-theme-select
+                                class="rounded-md border border-gray-300 bg-white px-2.5 py-1 text-sm font-medium text-gray-700 shadow-sm transition-colors duration-150 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-indigo-400">
+                                <option value="system">{{ __('System') }}</option>
+                                <option value="light">{{ __('Light') }}</option>
+                                <option value="dark">{{ __('Dark') }}</option>
+                            </select>
+                        </div>
 
                         <!-- Settings Dropdown -->
                         <div class="sm:flex sm:items-center sm:ms-6">
@@ -163,7 +173,7 @@
                                         $displayName = $userName !== '' ? $userName : $userEmail;
                                     @endphp
                                     <button
-                                        class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
+                                        class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150 dark:bg-gray-800 dark:text-gray-200 dark:hover:text-gray-100">
                                         <div>{{ $displayName }}</div>
 
                                         <div class="ms-1">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-<head class="h-full bg-white">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full" data-theme="system">
+<head>
     <title>{{ $title ?? 'Event Schedule' }}</title>
     <!-- Version: {{ config('self-update.version_installed') }} -->
     <meta charset="utf-8">
@@ -30,6 +30,36 @@
         <meta name="twitter:image:alt" content="Event Schedule">
         <meta name="twitter:card" content="summary_large_image">
     @endif    
+
+    <script {!! nonce_attr() !!}>
+        (() => {
+            const storageKey = 'theme';
+            const root = document.documentElement;
+            const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+            const getPreference = () => {
+                const stored = window.localStorage.getItem(storageKey);
+                if (stored === 'light' || stored === 'dark' || stored === 'system') {
+                    return stored;
+                }
+
+                return 'system';
+            };
+
+            const applyPreference = (preference) => {
+                const resolved = preference === 'system'
+                    ? (mediaQuery.matches ? 'dark' : 'light')
+                    : preference;
+
+                root.classList.toggle('dark', resolved === 'dark');
+                root.dataset.themePreference = preference;
+                root.dataset.themeResolved = resolved;
+                root.style.colorScheme = resolved;
+            };
+
+            applyPreference(getPreference());
+        })();
+    </script>
 
     <script src="{{ asset('js/jquery.min.js') }}"></script>
     <script type="text/javascript" src="{{ asset('js/toastify-js.js') }}"></script>
@@ -153,44 +183,46 @@
             font-family: sans-serif !important;
             position: absolute;
             padding: 5px 10px;
-            background: #333;
-            color: #fff;
+            background-color: var(--color-surface-muted);
+            color: var(--color-text-primary);
+            border: 1px solid var(--color-border);
             border-radius: 4px;
             display: none;
             font-size: 12px;
             z-index: 9999;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.15);
         }
 
         /* EasyMDE Toolbar Fixes */
         .editor-toolbar {
-            background-color: #f8f9fa !important; /* Temporarily change to light gray for debugging */
-            border-bottom: 1px solid #d1d5db !important;
+            background-color: var(--color-surface-muted) !important;
+            border-bottom: 1px solid var(--color-border) !important;
         }
 
         .editor-toolbar button,
         .editor-toolbar a,
         .editor-toolbar .fa,
         .editor-toolbar i {
-            color: #374151 !important;
+            color: var(--color-text-primary) !important;
             background-color: transparent !important;
             border: none !important;
-            text-shadow: 0 0 1px rgba(0,0,0,0.5) !important; /* Add text shadow for visibility */
+            text-shadow: none !important;
         }
 
         .editor-toolbar button:hover,
         .editor-toolbar a:hover {
-            background-color: #f3f4f6 !important;
-            color: #111827 !important;
+            background-color: var(--color-surface) !important;
+            color: var(--color-text-primary) !important;
         }
 
         .editor-toolbar button.active,
         .editor-toolbar a.active {
-            background-color: #e5e7eb !important;
-            color: #111827 !important;
+            background-color: var(--color-surface-muted) !important;
+            color: var(--color-text-primary) !important;
         }
 
         .editor-toolbar .separator {
-            border-left: 1px solid #d1d5db !important;
+            border-left: 1px solid var(--color-border) !important;
             border-right: none !important;
             color: transparent !important;
             font-size: 0 !important;
@@ -204,27 +236,27 @@
         /* Additional EasyMDE icon fixes */
         .editor-toolbar button:before,
         .editor-toolbar a:before {
-            color: #374151 !important;
-            text-shadow: 0 0 1px rgba(0,0,0,0.5) !important;
+            color: var(--color-text-primary) !important;
+            text-shadow: none !important;
         }
 
         .editor-toolbar button:hover:before,
         .editor-toolbar a:hover:before {
-            color: #111827 !important;
+            color: var(--color-text-primary) !important;
         }
 
         /* More specific EasyMDE fixes for different icon types */
         .CodeMirror .editor-toolbar > * {
-            color: #374151 !important;
+            color: var(--color-text-primary) !important;
         }
 
         .editor-toolbar > * {
-            color: #374151 !important;
+            color: var(--color-text-primary) !important;
         }
 
         .editor-toolbar > button > i,
         .editor-toolbar > a > i {
-            color: #374151 !important;
+            color: var(--color-text-primary) !important;
         }
 
         /* Force visibility of all toolbar elements */
@@ -327,7 +359,19 @@
     {{ isset($head) ? $head : '' }}
 
 </head> 
-<body class="font-sans antialiased h-full bg-gray-50">
+<body class="font-sans h-full bg-gray-50 text-gray-900 transition-colors duration-200 dark:bg-gray-950 dark:text-gray-100">
+
+    <div data-theme-floating-wrapper class="fixed bottom-4 right-4 z-40">
+        <label for="theme-preference-floating" class="sr-only">{{ __('Theme') }}</label>
+        <div class="rounded-full bg-white/90 p-2 shadow-lg ring-1 ring-gray-200 backdrop-blur dark:bg-gray-900/90 dark:ring-gray-700">
+            <select id="theme-preference-floating" data-theme-select data-theme-floating
+                class="rounded-full border border-transparent bg-transparent px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors duration-150 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-gray-100 dark:focus:border-indigo-400">
+                <option value="system">{{ __('System') }}</option>
+                <option value="light">{{ __('Light') }}</option>
+                <option value="dark">{{ __('Dark') }}</option>
+            </select>
+        </div>
+    </div>
 
     {{ $slot }}
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -38,12 +38,19 @@
             break;
         }
     }
+    $navLinkBase = 'group flex gap-x-3 rounded-md p-2 text-sm leading-6 transition-colors duration-150';
+    $navLinkDefault = 'text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white';
+    $navLinkActive = 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white';
+    $navSectionLabel = 'px-2 text-xs font-semibold leading-6 text-gray-500 dark:text-gray-400';
+    $pillBase = 'flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border text-[0.625rem] font-medium transition-colors duration-150';
+    $pillDefault = 'border-gray-300 bg-gray-100 text-gray-600 group-hover:text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:group-hover:text-white';
+    $pillActive = 'border-indigo-500 bg-indigo-500 text-white';
 @endphp
 
-<a href="https://www.eventschedule.com">
-    <div class="flex h-16 pt-2 shrink-0 items-center">
-        <img class="h-10 w-auto" src="{{ url('images/light_logo.png') }}"
-            alt="Event Schedule">
+<a href="https://www.eventschedule.com" class="block">
+    <div class="flex h-16 shrink-0 items-center pt-2">
+        <img class="h-10 w-auto dark:hidden" src="{{ url('images/light_logo.png') }}" alt="Event Schedule">
+        <img class="hidden h-10 w-auto dark:block" src="{{ url('images/dark_logo.png') }}" alt="Event Schedule">
     </div>
 </a>
 <nav class="flex flex-1 flex-col">
@@ -53,9 +60,9 @@
 
                 <li>
                     <a href="{{ route('home') }}"
-                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->is('events') ? 'bg-gray-800 text-white' : '' }}">
-                        <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24"
-                            fill="{{ request()->is('events') ? '#ccc' : '#666' }}" aria-hidden="true">
+                        class="{{ $navLinkBase }} font-semibold {{ request()->is('events') ? $navLinkActive : $navLinkDefault }}">
+                        <svg class="h-6 w-6 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24"
+                            fill="currentColor" aria-hidden="true">
                             <path d="M9,10V12H7V10H9M13,10V12H11V10H13M17,10V12H15V10H17M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5C3.89,21 3,20.1 3,19V5A2,2 0 0,1 5,3H6V1H8V3H16V1H18V3H19M19,19V8H5V19H19M9,14V16H7V14H9M13,14V16H11V14H13M17,14V16H15V14H17Z" />
                         </svg>
                         {{ __('messages.events') }}
@@ -64,9 +71,9 @@
 
                 <li>
                     <a href="{{ route('role.pages') }}"
-                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $schedulesActive ? 'bg-gray-800 text-white' : '' }}">
-                        <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24"
-                            fill="{{ $schedulesActive ? '#ccc' : '#666' }}" aria-hidden="true">
+                        class="{{ $navLinkBase }} font-semibold {{ $schedulesActive ? $navLinkActive : $navLinkDefault }}">
+                        <svg class="h-6 w-6 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24"
+                            fill="currentColor" aria-hidden="true">
                             <path d="M6 3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h9.5a2 2 0 0 0 2-2V8.5L13 3H6zm7 1.5L17.5 9H13V4.5z" />
                         </svg>
                         {{ __('messages.schedules') }}
@@ -76,9 +83,9 @@
                 <li data-collapse-container class="space-y-1" data-collapse-state="{{ $venuesSectionOpen ? 'open' : 'closed' }}">
                     <div class="flex items-center gap-x-2">
                         <a href="{{ route('role.venues') }}"
-                            class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $venuesSectionOpen ? 'bg-gray-800 text-white' : '' }}">
-                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none"
-                                stroke="{{ $venuesSectionOpen ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
+                            class="{{ $navLinkBase }} flex-1 font-medium {{ $venuesSectionOpen ? $navLinkActive : $navLinkDefault }}">
+                            <svg class="h-5 w-5 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                                 <path stroke-linecap="round" stroke-linejoin="round"
                                     d="M3 21h18M4.5 21V9l7.5-4.5L19.5 9V21M9 21v-6h6v6" />
                             </svg>
@@ -87,7 +94,7 @@
 
                         @if ($venues->isNotEmpty())
                             <button type="button"
-                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-500 transition-colors duration-150 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-gray-300 dark:hover:text-white"
                                 data-collapse-trigger aria-controls="collapse-venues"
                                 aria-expanded="{{ $venuesSectionOpen ? 'true' : 'false' }}">
                                 <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => __('messages.venues')]) }}</span>
@@ -102,7 +109,7 @@
                     @if ($venues->isNotEmpty())
                         <ul role="list" id="collapse-venues" data-collapse-content
                             class="mt-1 space-y-1 pl-9 {{ $venuesSectionOpen ? '' : 'hidden' }}">
-                            <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.venue_schedules') }}</li>
+                            <li class="{{ $navSectionLabel }}">{{ __('messages.venue_schedules') }}</li>
 
                             @foreach ($venues as $venue)
                                 @php
@@ -115,9 +122,9 @@
                                 @endphp
                                 <li>
                                     <a href="{{ route('role.view_admin', ['subdomain' => $venue->subdomain, 'tab' => $venue->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
-                                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
+                                        class="{{ $navLinkBase }} font-semibold {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? $navLinkActive : $navLinkDefault }}">
                                         <span
-                                            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ $venueInitial }}</span>
+                                            class="{{ $pillBase }} {{ request()->is($venue->subdomain) || request()->is($venue->subdomain . '/*') ? $pillActive : $pillDefault }}">{{ $venueInitial }}</span>
                                         <span class="truncate">{{ $venueName }}</span>
                                     </a>
                                 </li>
@@ -129,9 +136,9 @@
                 <li data-collapse-container class="space-y-1" data-collapse-state="{{ $curatorsSectionOpen ? 'open' : 'closed' }}">
                     <div class="flex items-center gap-x-2">
                         <a href="{{ route('role.curators') }}"
-                            class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $curatorsSectionOpen ? 'bg-gray-800 text-white' : '' }}">
-                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24"
-                                fill="{{ $curatorsSectionOpen ? '#ccc' : '#666' }}" aria-hidden="true">
+                            class="{{ $navLinkBase }} flex-1 font-medium {{ $curatorsSectionOpen ? $navLinkActive : $navLinkDefault }}">
+                            <svg class="h-5 w-5 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24"
+                                fill="currentColor" aria-hidden="true">
                                 <path d="M12 4l2.47 5.02 5.53.8-4 3.91.94 5.5L12 16.9l-4.94 2.33.94-5.5-4-3.91 5.53-.8L12 4z" />
                             </svg>
                             <span class="flex-1 text-left">{{ __('messages.curators') }}</span>
@@ -139,7 +146,7 @@
 
                         @if ($curators->isNotEmpty())
                             <button type="button"
-                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-500 transition-colors duration-150 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-gray-300 dark:hover:text-white"
                                 data-collapse-trigger aria-controls="collapse-curators"
                                 aria-expanded="{{ $curatorsSectionOpen ? 'true' : 'false' }}">
                                 <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => __('messages.curators')]) }}</span>
@@ -154,7 +161,7 @@
                     @if ($curators->isNotEmpty())
                         <ul role="list" id="collapse-curators" data-collapse-content
                             class="mt-1 space-y-1 pl-9 {{ $curatorsSectionOpen ? '' : 'hidden' }}">
-                            <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.curator_schedules') }}</li>
+                            <li class="{{ $navSectionLabel }}">{{ __('messages.curator_schedules') }}</li>
 
                             @foreach ($curators as $curator)
                                 @php
@@ -167,9 +174,9 @@
                                 @endphp
                                 <li>
                                     <a href="{{ route('role.view_admin', ['subdomain' => $curator->subdomain, 'tab' => $curator->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
-                                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
+                                        class="{{ $navLinkBase }} font-semibold {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? $navLinkActive : $navLinkDefault }}">
                                         <span
-                                            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ $curatorInitial }}</span>
+                                            class="{{ $pillBase }} {{ request()->is($curator->subdomain) || request()->is($curator->subdomain . '/*') ? $pillActive : $pillDefault }}">{{ $curatorInitial }}</span>
                                         <span class="truncate">{{ $curatorName }}</span>
                                     </a>
                                 </li>
@@ -181,9 +188,9 @@
                 <li data-collapse-container class="space-y-1" data-collapse-state="{{ $talentSectionOpen ? 'open' : 'closed' }}">
                     <div class="flex items-center gap-x-2">
                         <a href="{{ route('role.talent') }}"
-                            class="group flex flex-1 gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ $talentSectionOpen ? 'bg-gray-800 text-white' : '' }}">
-                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24"
-                                fill="{{ $talentSectionOpen ? '#ccc' : '#666' }}" aria-hidden="true">
+                            class="{{ $navLinkBase }} flex-1 font-medium {{ $talentSectionOpen ? $navLinkActive : $navLinkDefault }}">
+                            <svg class="h-5 w-5 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24"
+                                fill="currentColor" aria-hidden="true">
                                 <path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8zm0 2c-3.33 0-6 2.24-6 5v1h12v-1c0-2.76-2.67-5-6-5z" />
                             </svg>
                             <span class="flex-1 text-left">{{ \Illuminate\Support\Str::plural(__('messages.talent')) }}</span>
@@ -191,7 +198,7 @@
 
                         @if ($schedules->isNotEmpty())
                             <button type="button"
-                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                class="ml-1 inline-flex items-center rounded-md p-1 text-gray-500 transition-colors duration-150 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:text-gray-300 dark:hover:text-white"
                                 data-collapse-trigger aria-controls="collapse-talent"
                                 aria-expanded="{{ $talentSectionOpen ? 'true' : 'false' }}">
                                 <span class="sr-only">{{ __('Toggle :menu menu', ['menu' => \Illuminate\Support\Str::plural(__('messages.talent'))]) }}</span>
@@ -206,7 +213,7 @@
                     @if ($schedules->isNotEmpty())
                         <ul role="list" id="collapse-talent" data-collapse-content
                             class="mt-1 space-y-1 pl-9 {{ $talentSectionOpen ? '' : 'hidden' }}">
-                            <li class="px-2 text-xs font-semibold leading-6 text-gray-400">{{ __('messages.talent_schedules') }}</li>
+                            <li class="{{ $navSectionLabel }}">{{ __('messages.talent_schedules') }}</li>
 
                             @foreach ($schedules as $each)
                                 @php
@@ -219,9 +226,9 @@
                                 @endphp
                                 <li>
                                     <a href="{{ route('role.view_admin', ['subdomain' => $each->subdomain, 'tab' => $each->subdomain == request()->subdomain ? 'schedule' : (request()->tab ? request()->tab : 'schedule')]) }}"
-                                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 hover:bg-gray-800 hover:text-white {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? 'bg-gray-800 text-white' : 'text-gray-400' }}">
+                                        class="{{ $navLinkBase }} font-semibold {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? $navLinkActive : $navLinkDefault }}">
                                         <span
-                                            class="flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border border-gray-700 bg-gray-800 text-[0.625rem] font-medium group-hover:text-white {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? 'text-white' : 'text-gray-400' }}">{{ $scheduleInitial }}</span>
+                                            class="{{ $pillBase }} {{ request()->is($each->subdomain) || request()->is($each->subdomain . '/*') ? $pillActive : $pillDefault }}">{{ $scheduleInitial }}</span>
                                         <span class="truncate">{{ $scheduleName }}</span>
                                     </a>
                                 </li>
@@ -233,8 +240,8 @@
                 @if (\Illuminate\Support\Facades\Route::has('role.contacts'))
                     <li>
                         <a href="{{ route('role.contacts') }}"
-                            class="group flex gap-x-3 rounded-md p-2 text-sm font-medium leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('role.contacts') ? 'bg-gray-800 text-white' : '' }}">
-                            <svg class="h-5 w-5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="{{ request()->routeIs('role.contacts') ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
+                            class="{{ $navLinkBase }} font-medium {{ request()->routeIs('role.contacts') ? $navLinkActive : $navLinkDefault }}">
+                            <svg class="h-5 w-5 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 5.25h15a.75.75 0 01.75.75v12.75a.75.75 0 01-.75.75h-15a.75.75 0 01-.75-.75V6a.75.75 0 01.75-.75z" />
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 8.25h7.5M8.25 12h4.5M8.25 15.75H12" />
                             </svg>
@@ -246,9 +253,9 @@
                 @if (config('app.hosted'))
                 <li>
                     <a href="{{ route('tickets') }}"
-                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->is('tickets') ? 'bg-gray-800 text-white' : '' }}">
-                        <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24"
-                            fill="{{ request()->is('tickets') ? '#ccc' : '#666' }}" aria-hidden="true">
+                        class="{{ $navLinkBase }} font-semibold {{ request()->is('tickets') ? $navLinkActive : $navLinkDefault }}">
+                        <svg class="h-6 w-6 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24"
+                            fill="currentColor" aria-hidden="true">
                             <path d="M13,8.5H11V6.5H13V8.5M13,13H11V11H13V13M13,17.5H11V15.5H13V17.5M22,10V6C22,4.89 21.1,4 20,4H4A2,2 0 0,0 2,6V10C3.11,10 4,10.9 4,12A2,2 0 0,1 2,14V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V14A2,2 0 0,1 20,12A2,2 0 0,1 22,10Z" />
                         </svg>
                         {{ __('messages.tickets') }}
@@ -258,9 +265,9 @@
 
                 <li>
                     <a href="{{ route('sales') }}"
-                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->is('sales') ? 'bg-gray-800 text-white' : '' }}">
-                        <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24"
-                            fill="{{ request()->is('sales') ? '#ccc' : '#666' }}" aria-hidden="true">
+                        class="{{ $navLinkBase }} font-semibold {{ request()->is('sales') ? $navLinkActive : $navLinkDefault }}">
+                        <svg class="h-6 w-6 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24"
+                            fill="currentColor" aria-hidden="true">
                             <path d="M20,8H4V6H20M20,18H4V12H20M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4Z" />
                         </svg>
                         {{ __('messages.sales') }}
@@ -269,8 +276,8 @@
 
                 <li>
                     <a href="{{ route('media.index') }}"
-                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->routeIs('media.*') ? 'bg-gray-800 text-white' : '' }}">
-                        <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24" fill="none" stroke="{{ request()->routeIs('media.*') ? '#ccc' : '#666' }}" stroke-width="1.5" aria-hidden="true">
+                        class="{{ $navLinkBase }} font-semibold {{ request()->routeIs('media.*') ? $navLinkActive : $navLinkDefault }}">
+                        <svg class="h-6 w-6 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                             <rect x="3" y="5" width="18" height="14" rx="2" ry="2"></rect>
                             <path d="M3 16l4.5-4.5a1 1 0 0 1 1.414 0L15 18"></path>
                             <path d="M11 13l2-2a1 1 0 0 1 1.414 0L21 18"></path>
@@ -283,9 +290,9 @@
                 @if (config('app.hosted') && auth()->user()->isAdmin())
                 <li>
                     <a href="{{ route('blog.admin.index') }}"
-                        class="group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->is('admin/blog*') ? 'bg-gray-800 text-white' : '' }}">
-                        <svg class="h-6 w-6 shrink-0" viewBox="0 0 24 24"
-                            fill="{{ request()->is('admin/blog*') ? '#ccc' : '#666' }}" aria-hidden="true">
+                        class="{{ $navLinkBase }} font-semibold {{ request()->is('admin/blog*') ? $navLinkActive : $navLinkDefault }}">
+                        <svg class="h-6 w-6 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" viewBox="0 0 24 24"
+                            fill="currentColor" aria-hidden="true">
                             <path d="M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3M19,19H5V5H19V19M17,17H7V15H17V17M17,13H7V11H17V13M17,9H7V7H17V9Z" />
                         </svg>
                         Blog
@@ -300,8 +307,8 @@
         @if (auth()->user()->isAdmin())
         <li class="mt-auto">
             <a href="{{ route('settings.index') }}"
-                class="group -mx-2 flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-400 hover:bg-gray-800 hover:text-white {{ request()->is('settings*') ? 'bg-gray-800 text-white' : '' }}">
-                <svg class="h-6 w-6 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                class="{{ $navLinkBase }} -mx-2 font-semibold {{ request()->is('settings*') ? $navLinkActive : $navLinkDefault }}">
+                <svg class="h-6 w-6 shrink-0 text-gray-400 transition-colors duration-150 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-200" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
                     stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round"
                         d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ import forms from '@tailwindcss/forms';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './storage/framework/views/*.php',


### PR DESCRIPTION
## Summary
- enable Tailwind's class-based dark mode and define shared color tokens for light and dark surfaces
- add a global theme manager with local storage support, floating selector, and admin toolbar control
- refresh navigation styling to keep icons, links, and pills legible in both dark and light contexts

## Testing
- npm run build *(fails: vite: not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf08789d0832ea8f79bef938f8b5f