### PR TITLE
Prevent duplicate email notifications per action

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -100,25 +100,17 @@ class EventController extends Controller
     {
         $event->loadMissing(['roles.members', 'venue.members', 'creatorRole.members', 'sales']);
 
-        foreach ($event->roles as $roleModel) {
-            if ($roleModel->isTalent()) {
-                $members = NotificationUtils::roleMembers($roleModel);
+        $talentRoles = $event->roles->filter(fn ($roleModel) => $roleModel->isTalent());
 
-                if ($members->isNotEmpty()) {
-                    Notification::send($members, new DeletedEventNotification($event, $user, 'talent', $roleModel));
-                }
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($talentRoles)->each(function (array $recipient) use ($event, $user) {
+            $recipient['user']->notify(new DeletedEventNotification($event, $user, 'talent', $recipient['role']));
+        });
 
         $organizerRoles = collect([$event->creatorRole, $event->venue])->filter();
 
-        foreach ($organizerRoles as $organizerRole) {
-            $members = NotificationUtils::roleMembers($organizerRole);
-
-            if ($members->isNotEmpty()) {
-                Notification::send($members, new DeletedEventNotification($event, $user, 'organizer', $organizerRole));
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($organizerRoles)->each(function (array $recipient) use ($event, $user) {
+            $recipient['user']->notify(new DeletedEventNotification($event, $user, 'organizer', $recipient['role']));
+        });
 
         $purchaserEmails = NotificationUtils::purchaserEmails($event);
 
@@ -673,25 +665,17 @@ class EventController extends Controller
 
         $event->load(['roles.members', 'venue.members', 'creatorRole.members']);
 
-        foreach ($event->roles as $talentRole) {
-            if ($talentRole->isTalent()) {
-                $members = NotificationUtils::roleMembers($talentRole);
+        $talentRoles = $event->roles->filter(fn ($talentRole) => $talentRole->isTalent());
 
-                if ($members->isNotEmpty()) {
-                    Notification::send($members, new RequestAcceptedNotification($event, $user, 'talent', $talentRole));
-                }
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($talentRoles)->each(function (array $recipient) use ($event, $user) {
+            $recipient['user']->notify(new RequestAcceptedNotification($event, $user, 'talent', $recipient['role']));
+        });
 
         $organizerRoles = collect([$event->creatorRole, $event->venue])->filter();
 
-        foreach ($organizerRoles as $organizerRole) {
-            $members = NotificationUtils::roleMembers($organizerRole);
-
-            if ($members->isNotEmpty()) {
-                Notification::send($members, new RequestAcceptedNotification($event, $user, 'organizer', $organizerRole));
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($organizerRoles)->each(function (array $recipient) use ($event, $user) {
+            $recipient['user']->notify(new RequestAcceptedNotification($event, $user, 'organizer', $recipient['role']));
+        });
 
         return redirect('/' . $subdomain . '/requests')
                     ->with('message', __('messages.request_accepted'));
@@ -714,25 +698,17 @@ class EventController extends Controller
 
         $event->load(['roles.members', 'venue.members', 'creatorRole.members']);
 
-        foreach ($event->roles as $talentRole) {
-            if ($talentRole->isTalent()) {
-                $members = NotificationUtils::roleMembers($talentRole);
+        $talentRoles = $event->roles->filter(fn ($talentRole) => $talentRole->isTalent());
 
-                if ($members->isNotEmpty()) {
-                    Notification::send($members, new RequestDeclinedNotification($event, $user, 'talent', $talentRole));
-                }
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($talentRoles)->each(function (array $recipient) use ($event, $user) {
+            $recipient['user']->notify(new RequestDeclinedNotification($event, $user, 'talent', $recipient['role']));
+        });
 
         $organizerRoles = collect([$event->creatorRole, $event->venue])->filter();
 
-        foreach ($organizerRoles as $organizerRole) {
-            $members = NotificationUtils::roleMembers($organizerRole);
-
-            if ($members->isNotEmpty()) {
-                Notification::send($members, new RequestDeclinedNotification($event, $user, 'organizer', $organizerRole));
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($organizerRoles)->each(function (array $recipient) use ($event, $user) {
+            $recipient['user']->notify(new RequestDeclinedNotification($event, $user, 'organizer', $recipient['role']));
+        });
 
         if ($request->redirect_to == 'schedule') {
             return redirect('/' . $subdomain . '/schedule')

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -64,14 +64,10 @@ class Sale extends Model
         $notifiedUserIds = collect();
         $organizerRoles = collect([$event->creatorRole, $event->venue])->filter();
 
-        foreach ($organizerRoles as $organizerRole) {
-            $members = NotificationUtils::roleMembers($organizerRole);
-
-            if ($members->isNotEmpty()) {
-                Notification::send($members, new TicketCancelledNotification($sale, 'organizer', $organizerRole));
-                $notifiedUserIds = $notifiedUserIds->merge($members->pluck('id'));
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($organizerRoles)->each(function (array $recipient) use (&$notifiedUserIds, $sale) {
+            $recipient['user']->notify(new TicketCancelledNotification($sale, 'organizer', $recipient['role']));
+            $notifiedUserIds->push($recipient['user']->id);
+        });
 
         if ($event->user && $event->user->email && $event->user->is_subscribed !== false && ! $notifiedUserIds->contains($event->user->id)) {
             Notification::send($event->user, new TicketCancelledNotification($sale, 'organizer', $contextRole));
@@ -91,14 +87,10 @@ class Sale extends Model
         $notifiedUserIds = collect();
         $organizerRoles = collect([$event->creatorRole, $event->venue])->filter();
 
-        foreach ($organizerRoles as $organizerRole) {
-            $members = NotificationUtils::roleMembers($organizerRole);
-
-            if ($members->isNotEmpty()) {
-                Notification::send($members, new TicketPaidNotification($sale, 'organizer', $organizerRole));
-                $notifiedUserIds = $notifiedUserIds->merge($members->pluck('id'));
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($organizerRoles)->each(function (array $recipient) use (&$notifiedUserIds, $sale) {
+            $recipient['user']->notify(new TicketPaidNotification($sale, 'organizer', $recipient['role']));
+            $notifiedUserIds->push($recipient['user']->id);
+        });
 
         if ($event->user && $event->user->email && $event->user->is_subscribed !== false && ! $notifiedUserIds->contains($event->user->id)) {
             Notification::send($event->user, new TicketPaidNotification($sale, 'organizer', $contextRole));
@@ -118,14 +110,10 @@ class Sale extends Model
         $notifiedUserIds = collect();
         $organizerRoles = collect([$event->creatorRole, $event->venue])->filter();
 
-        foreach ($organizerRoles as $organizerRole) {
-            $members = NotificationUtils::roleMembers($organizerRole);
-
-            if ($members->isNotEmpty()) {
-                Notification::send($members, new TicketTimeoutNotification($sale, 'organizer', $organizerRole));
-                $notifiedUserIds = $notifiedUserIds->merge($members->pluck('id'));
-            }
-        }
+        NotificationUtils::uniqueRoleMembersWithContext($organizerRoles)->each(function (array $recipient) use (&$notifiedUserIds, $sale) {
+            $recipient['user']->notify(new TicketTimeoutNotification($sale, 'organizer', $recipient['role']));
+            $notifiedUserIds->push($recipient['user']->id);
+        });
 
         if ($event->user && $event->user->email && $event->user->is_subscribed !== false && ! $notifiedUserIds->contains($event->user->id)) {
             Notification::send($event->user, new TicketTimeoutNotification($sale, 'organizer', $contextRole));


### PR DESCRIPTION
## Summary
- add a utility to gather unique role members while preserving their context
- update sale, ticket, and event notification flows to only email each recipient once per action

## Testing
- composer test *(fails: Command "test" is not defined.)*
- vendor/bin/phpunit *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf5a29338832e901919be957e219b