### PR TITLE
Fix Add Type button on event tickets form

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -911,7 +911,7 @@
                                                     class="mt-1 block w-full" required />
                                             </div>
                                             <div v-if="tickets.length > 1" class="flex items-end">
-                                                <x-secondary-button x-on:click="removeTicket(index)" type="button" class="mt-1">
+                                    <x-secondary-button @click="removeTicket(index)" type="button" class="mt-1">
                                                     {{ __('messages.remove') }}
                                                 </x-secondary-button>
                                             </div>
@@ -951,7 +951,7 @@
                                         </div>
                                     </div>
 
-                                    <x-secondary-button x-on:click="addTicket" type="button" class="mt-4">
+                                    <x-secondary-button @click="addTicket" type="button" class="mt-4">
                                         {{ __('messages.add_type') }}
                                     </x-secondary-button>
                                 </div>


### PR DESCRIPTION
## Summary
- switch the ticket removal button on the event edit form to use Vue's @click handler
- update the Add Type button to use Vue's @click handler so it properly triggers addTicket

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fbf830fbcc832ebe81380c25a671ff