### PR TITLE
Add multipart encoding to general settings form

### DIFF
--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -108,7 +108,7 @@
                             </p>
                         </header>
 
-                        <form method="post" action="{{ route('settings.general.update') }}" class="mt-6 space-y-6">
+                        <form method="post" action="{{ route('settings.general.update') }}" class="mt-6 space-y-6" enctype="multipart/form-data">
                             @csrf
                             @method('patch')
 


### PR DESCRIPTION
## Summary
- update the general settings form to send file uploads by specifying multipart encoding

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68fc2d016de8832e90aecbdf72d37879