### PR TITLE
Fix branding reset clearing custom colors

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -549,7 +549,7 @@ class SettingsController extends Controller
                 $this->deleteStoredFile($previousLogoPath, $previousLogoDisk);
             }
 
-            Setting::setGroup('branding', []);
+            Setting::clearGroup('branding');
             BrandingManager::apply();
 
             return redirect()->route('settings.branding')->with('status', 'branding-settings-reset');

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -38,6 +38,13 @@ class Setting extends Model
         Cache::forget(static::cacheKey($group));
     }
 
+    public static function clearGroup(string $group): void
+    {
+        static::query()->where('group', $group)->delete();
+
+        Cache::forget(static::cacheKey($group));
+    }
+
     protected static function cacheKey(string $group): string
     {
         return "settings.{$group}";


### PR DESCRIPTION
## Summary
- add a Setting::clearGroup helper to fully remove stored settings for a group
- call the helper when resetting branding so cached values are flushed and defaults apply

## Testing
- php artisan test --filter=SettingsTest *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fc34e3ef50832ebba87ebc4e7e5f30