### PR TITLE
Normalize release version handling for online updater

### DIFF
--- a/app/Console/Commands/UpdateApp.php
+++ b/app/Console/Commands/UpdateApp.php
@@ -41,7 +41,9 @@ class UpdateApp extends Command
         $this->info(sprintf('Updating app via the %s channel. This can take a few minutes...', $channel->label()));
 
         try {
-            $versionAvailable = $releaseChannels->getLatestVersion($channel);
+            $latestRelease = $releaseChannels->getLatestRelease($channel);
+            $versionAvailable = $latestRelease['version'];
+            $releaseTag = $latestRelease['tag'];
             $installedVersion = $updater->source()->getVersionInstalled();
         } catch (Throwable $exception) {
             $this->error($exception->getMessage());
@@ -56,7 +58,7 @@ class UpdateApp extends Command
         }
 
         try {
-            $release = $updater->source()->fetch($versionAvailable);
+            $release = $updater->source()->fetch($releaseTag);
 
             $updater->source()->update($release);
 

--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -45,13 +45,15 @@ class AppController extends Controller
 
         try {
             $versionInstalled = $updater->source()->getVersionInstalled();
-            $versionAvailable = $releaseChannels->getLatestVersion($channel);
+            $latestRelease = $releaseChannels->getLatestRelease($channel);
+            $versionAvailable = $latestRelease['version'];
+            $releaseTag = $latestRelease['tag'];
 
             if ($versionInstalled === $versionAvailable) {
                 return redirect()->back()->with('error', __('messages.no_new_version_available'));
             }
 
-            $release = $updater->source()->fetch($versionAvailable);
+            $release = $updater->source()->fetch($releaseTag);
 
             $updater->source()->update($release);
 

--- a/app/Services/ReleaseChannelService.php
+++ b/app/Services/ReleaseChannelService.php
@@ -138,10 +138,26 @@ class ReleaseChannelService
             throw new RuntimeException('Release data is missing the tag_name attribute.');
         }
 
+        $tag = (string) $release['tag_name'];
+
         return [
-            'version' => (string) $release['tag_name'],
+            'version' => $this->normalizeVersionString($tag),
+            'tag' => $tag,
             'name' => (string) ($release['name'] ?? $release['tag_name']),
             'prerelease' => (bool) ($release['prerelease'] ?? false),
         ];
+    }
+
+    private function normalizeVersionString(string $tag): string
+    {
+        if ($tag === '') {
+            return $tag;
+        }
+
+        if (preg_match('/^v(.+)/i', $tag, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return $tag;
     }
 }

--- a/tests/Unit/Services/ReleaseChannelServiceTest.php
+++ b/tests/Unit/Services/ReleaseChannelServiceTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\ReleaseChannelService;
+use ReflectionClass;
+use RuntimeException;
+use Tests\TestCase;
+
+class ReleaseChannelServiceTest extends TestCase
+{
+    public function testNormalizeReleaseDataStripsLeadingVFromTag(): void
+    {
+        $service = new ReleaseChannelService();
+
+        $normalized = $this->normalizeReleaseData($service, [
+            'tag_name' => 'v5.0.16',
+            'name' => 'Release v5.0.16',
+            'prerelease' => false,
+        ]);
+
+        $this->assertSame('5.0.16', $normalized['version']);
+        $this->assertSame('v5.0.16', $normalized['tag']);
+    }
+
+    public function testNormalizeReleaseDataPreservesVersionWithoutLeadingV(): void
+    {
+        $service = new ReleaseChannelService();
+
+        $normalized = $this->normalizeReleaseData($service, [
+            'tag_name' => '5.0.16-beta1',
+            'name' => '5.0.16-beta1',
+            'prerelease' => true,
+        ]);
+
+        $this->assertSame('5.0.16-beta1', $normalized['version']);
+        $this->assertSame('5.0.16-beta1', $normalized['tag']);
+    }
+
+    public function testNormalizeReleaseDataRequiresTagName(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $service = new ReleaseChannelService();
+
+        $this->normalizeReleaseData($service, []);
+    }
+
+    private function normalizeReleaseData(ReleaseChannelService $service, array $release): array
+    {
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('normalizeReleaseData');
+        $method->setAccessible(true);
+
+        return $method->invoke($service, $release);
+    }
+}


### PR DESCRIPTION
## Summary
- normalize GitHub tag versions before comparing them with the installed VERSION
- fetch releases using the raw tag so remote downloads continue to work
- add coverage around release normalization to guard against regressions

## Testing
- not run (composer install requires GitHub token in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68fc38bb2224832eb7c02e902dee234f