### PR TITLE
Fix branding palette data binding

### DIFF
--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -128,9 +128,9 @@
 
                         <form method="post" action="{{ route('settings.branding.update') }}" class="mt-6 space-y-6"
                             x-data="brandingColorForm({
-                                colors: @json($currentColors),
-                                defaults: @json($defaultColors),
-                                palettes: @json($colorPalettes),
+                                colors: @js($currentColors),
+                                defaults: @js($defaultColors),
+                                palettes: @js($colorPalettes),
                             })"
                             x-init="init()">
                             @csrf


### PR DESCRIPTION
## Summary
- use the @js Blade directive when passing branding color data to the Alpine component so preset palettes are available

## Testing
- composer install --no-interaction --no-progress *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fc3ec160c0832eb9e16b85b89c9f0d