### PR TITLE
Handle failed updater responses

### DIFF
--- a/app/Console/Commands/UpdateApp.php
+++ b/app/Console/Commands/UpdateApp.php
@@ -8,6 +8,7 @@ use App\Support\ReleaseChannelManager;
 use Codedge\Updater\UpdaterManager;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
+use RuntimeException;
 use Throwable;
 class UpdateApp extends Command
 {
@@ -60,7 +61,13 @@ class UpdateApp extends Command
         try {
             $release = $updater->source()->fetch($releaseTag);
 
-            $updater->source()->update($release);
+            $updateResult = $updater->source()->update($release);
+
+            if ($updateResult === false) {
+                throw new RuntimeException(
+                    'The update could not be installed. Please check the application logs for more details.'
+                );
+            }
 
             Artisan::call('migrate', ['--force' => true]);
         } catch (Throwable $exception) {

--- a/app/Http/Controllers/AppController.php
+++ b/app/Http/Controllers/AppController.php
@@ -55,7 +55,13 @@ class AppController extends Controller
 
             $release = $updater->source()->fetch($releaseTag);
 
-            $updater->source()->update($release);
+            $updateResult = $updater->source()->update($release);
+
+            if ($updateResult === false) {
+                throw new RuntimeException(
+                    'The update could not be installed. Please check the application logs for more details.'
+                );
+            }
 
             Artisan::call('migrate', ['--force' => true]);
         } catch (\Throwable $e) {

--- a/tests/Feature/Console/UpdateAppCommandTest.php
+++ b/tests/Feature/Console/UpdateAppCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Services\ReleaseChannelService;
+use Codedge\Updater\UpdaterManager;
+use Illuminate\Support\Facades\Artisan as ArtisanFacade;
+use Mockery;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Tests\TestCase;
+
+class UpdateAppCommandTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testCommandFailsWhenUpdaterReturnsFalse(): void
+    {
+        config([
+            'app.hosted' => false,
+            'self-update.release_channel' => 'production',
+        ]);
+
+        ArtisanFacade::shouldReceive('call')->never();
+
+        $source = Mockery::mock();
+        $updater = Mockery::mock(UpdaterManager::class);
+        $releaseChannels = Mockery::mock(ReleaseChannelService::class);
+
+        $updater->shouldReceive('source')->times(3)->andReturn($source);
+        $source->shouldReceive('getVersionInstalled')->once()->andReturn('1.0.0');
+
+        $releaseChannels->shouldReceive('getLatestRelease')->once()->andReturn([
+            'version' => '2.0.0',
+            'tag' => 'v2.0.0',
+        ]);
+
+        $source->shouldReceive('fetch')->once()->with('v2.0.0')->andReturn('release');
+        $source->shouldReceive('update')->once()->with('release')->andReturn(false);
+
+        $this->app->instance(UpdaterManager::class, $updater);
+        $this->app->instance(ReleaseChannelService::class, $releaseChannels);
+
+        $this->artisan('app:update')
+            ->expectsOutput('Updating app via the Production (stable) channel. This can take a few minutes...')
+            ->expectsOutput('The update could not be installed. Please check the application logs for more details.')
+            ->assertExitCode(SymfonyCommand::FAILURE);
+    }
+}

--- a/tests/Unit/Http/Controllers/AppControllerTest.php
+++ b/tests/Unit/Http/Controllers/AppControllerTest.php
@@ -3,14 +3,25 @@
 namespace Tests\Unit\Http\Controllers;
 
 use App\Http\Controllers\AppController;
+use App\Services\ReleaseChannelService;
+use Codedge\Updater\UpdaterManager;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Mockery;
 use ReflectionClass;
 use RuntimeException;
 use Tests\TestCase;
 
 class AppControllerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
     public function testCopyReleaseContentsReportsAllUnwritableDirectories(): void
     {
         $root = storage_path('framework/testing/copy-release-' . (string) Str::uuid());
@@ -65,6 +76,39 @@ class AppControllerTest extends TestCase
                 File::deleteDirectory($root);
             }
         }
+    }
+
+    public function testOnlineUpdateReportsFailureWhenUpdaterReturnsFalse(): void
+    {
+        config([
+            'app.hosted' => false,
+            'self-update.release_channel' => 'production',
+        ]);
+
+        Artisan::shouldReceive('call')->never();
+
+        $source = Mockery::mock();
+        $updater = Mockery::mock(UpdaterManager::class);
+        $releaseChannels = Mockery::mock(ReleaseChannelService::class);
+
+        $updater->shouldReceive('source')->times(3)->andReturn($source);
+        $source->shouldReceive('getVersionInstalled')->once()->andReturn('1.0.0');
+
+        $releaseChannels->shouldReceive('getLatestRelease')->once()->andReturn([
+            'version' => '2.0.0',
+            'tag' => 'v2.0.0',
+        ]);
+
+        $source->shouldReceive('fetch')->once()->with('v2.0.0')->andReturn('release');
+        $source->shouldReceive('update')->once()->with('release')->andReturn(false);
+
+        $this->app->instance(UpdaterManager::class, $updater);
+        $this->app->instance(ReleaseChannelService::class, $releaseChannels);
+
+        $response = $this->from('/update')->post('/update');
+
+        $response->assertRedirect('/update');
+        $response->assertSessionHas('error', 'The update could not be installed. Please check the application logs for more details.');
     }
 
     private function invokeCopyReleaseContents(AppController $controller, string $source, string $destination): void


### PR DESCRIPTION
## Summary
- treat a false response from the updater service as a failure in both the web and CLI update flows
- add automated tests to ensure failed updates surface an error instead of a success message

## Testing
- php artisan test *(fails: vendor/autoload.php missing because composer install requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68fc41a9e96c832ea85c76e47609d410