### PR TITLE
Use media library for schedule backgrounds

### DIFF
--- a/app/Http/Requests/RoleCreateRequest.php
+++ b/app/Http/Requests/RoleCreateRequest.php
@@ -27,6 +27,8 @@ class RoleCreateRequest extends FormRequest
             'profile_image_id' => ['nullable', 'integer', 'exists:images,id'],
             'background_image_id' => ['nullable', 'integer', 'exists:images,id'],
             'background_image' => ['nullable', 'string', 'max:255'],
+            'background_media_asset_id' => ['nullable', 'integer', 'exists:media_assets,id'],
+            'background_media_variant_id' => ['nullable', 'integer', 'exists:media_asset_variants,id'],
             'contacts' => ['nullable', 'array'],
             'contacts.*.name' => ['nullable', 'string', 'max:255'],
             'contacts.*.email' => array_merge(

--- a/app/Support/ScheduleBackgroundManager.php
+++ b/app/Support/ScheduleBackgroundManager.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\MediaAsset;
+use App\Models\MediaTag;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Throwable;
+
+class ScheduleBackgroundManager
+{
+    private const STORAGE_FOLDER = 'media/schedule/backgrounds';
+    private const TAG_SLUG = 'schedule-backgrounds';
+    private const TAG_NAME = 'Schedule backgrounds';
+    private const FILE_GLOB_PATTERN = 'images/backgrounds/*.png';
+
+    /**
+     * Retrieve all schedule background assets from the media library, importing bundled
+     * backgrounds if they have not yet been added.
+     */
+    public static function backgroundAssets(): Collection
+    {
+        self::importBundledBackgrounds();
+
+        return MediaAsset::query()
+            ->with('variants')
+            ->where('folder', self::STORAGE_FOLDER)
+            ->orderBy('original_filename')
+            ->get();
+    }
+
+    /**
+     * Locate a bundled background asset by its original filename (with or without extension).
+     */
+    public static function findBackgroundByIdentifier(?string $identifier): ?MediaAsset
+    {
+        if (! is_string($identifier) || trim($identifier) === '') {
+            return null;
+        }
+
+        $normalized = trim($identifier);
+        if (! Str::endsWith(Str::lower($normalized), '.png')) {
+            $normalized .= '.png';
+        }
+
+        return MediaAsset::query()
+            ->where('folder', self::STORAGE_FOLDER)
+            ->where('original_filename', $normalized)
+            ->first();
+    }
+
+    /**
+     * Retrieve a random bundled background asset from the media library.
+     */
+    public static function randomBackgroundAsset(): ?MediaAsset
+    {
+        $assets = self::backgroundAssets();
+
+        if ($assets->isEmpty()) {
+            return null;
+        }
+
+        return $assets->random();
+    }
+
+    /**
+     * Ensure the bundled schedule backgrounds are imported into the media library.
+     */
+    private static function importBundledBackgrounds(): void
+    {
+        $publicPath = public_path(self::FILE_GLOB_PATTERN);
+        $paths = glob($publicPath) ?: [];
+
+        if (empty($paths)) {
+            return;
+        }
+
+        $disk = storage_public_disk();
+        $storage = Storage::disk($disk);
+        $tag = self::resolveBackgroundTag();
+
+        foreach ($paths as $path) {
+            if (! is_string($path) || ! is_file($path) || ! is_readable($path)) {
+                continue;
+            }
+
+            $basename = pathinfo($path, PATHINFO_BASENAME);
+            if (! is_string($basename) || $basename === '') {
+                continue;
+            }
+
+            $relativePath = trim(self::STORAGE_FOLDER . '/' . $basename, '/');
+
+            try {
+                $contents = file_get_contents($path);
+            } catch (Throwable $exception) {
+                Log::warning('Failed to read bundled background for import', [
+                    'path' => $path,
+                    'exception' => $exception->getMessage(),
+                ]);
+                continue;
+            }
+
+            if ($contents === false) {
+                continue;
+            }
+
+            try {
+                if (! $storage->exists($relativePath)) {
+                    $storage->put($relativePath, $contents, ['visibility' => 'public']);
+                }
+            } catch (Throwable $exception) {
+                Log::warning('Failed to store bundled background in media library', [
+                    'disk' => $disk,
+                    'relative_path' => $relativePath,
+                    'exception' => $exception->getMessage(),
+                ]);
+                continue;
+            }
+
+            $dimensions = @getimagesize($path) ?: [null, null];
+            $size = @filesize($path);
+
+            $attributes = [
+                'disk' => $disk,
+                'path' => $relativePath,
+                'folder' => self::STORAGE_FOLDER,
+                'original_filename' => $basename,
+                'mime_type' => 'image/png',
+                'size' => is_int($size) ? $size : null,
+                'width' => $dimensions[0] ?? null,
+                'height' => $dimensions[1] ?? null,
+            ];
+
+            $asset = MediaAsset::query()
+                ->where('folder', self::STORAGE_FOLDER)
+                ->where('original_filename', $basename)
+                ->first();
+
+            if ($asset) {
+                $asset->fill($attributes);
+                if ($asset->isDirty()) {
+                    $asset->save();
+                }
+            } else {
+                $asset = MediaAsset::create($attributes);
+            }
+
+            if ($asset) {
+                $asset->tags()->syncWithoutDetaching([$tag->id]);
+            }
+        }
+    }
+
+    private static function resolveBackgroundTag(): MediaTag
+    {
+        return MediaTag::firstOrCreate(
+            ['slug' => self::TAG_SLUG],
+            ['name' => self::TAG_NAME]
+        );
+    }
+}
+

--- a/resources/views/layouts/app-guest.blade.php
+++ b/resources/views/layouts/app-guest.blade.php
@@ -107,7 +107,7 @@
                     @if ($otherRole->background_image)
                         background-image: url("{{ asset('images/backgrounds/' . $otherRole->background_image . '.png') }}");
                     @else
-                        background-image: url("{{ $otherRole->background_image_url }}");
+                        background-image: url("{{ storage_asset_url($otherRole->background_image_url) }}");
                     @endif
                     background-size: cover;
                     background-position: center;
@@ -127,11 +127,11 @@
                             @endif
                         url("{{ asset('images/backgrounds/' . $role->background_image . '.png') }}");
                     @else
-                        background-image: 
+                        background-image:
                             @if (request()->graphic)
                                 linear-gradient(rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0.5)),
                             @endif
-                        url("{{ $role->background_image_url }}");
+                        url("{{ storage_asset_url($role->background_image_url) }}");
                     @endif
                     background-size: cover;
                     background-position: center;

--- a/resources/views/testing/role/partials/form-fields.blade.php
+++ b/resources/views/testing/role/partials/form-fields.blade.php
@@ -12,7 +12,14 @@
 <input type="hidden" name="background" value="{{ old('background', $role->background) }}">
 <input type="hidden" name="background_colors" value="{{ old('background_colors', $role->background_colors) }}">
 <input type="hidden" name="background_color" value="{{ old('background_color', $role->background_color) }}">
+@php
+    $backgroundDefaults = is_array($backgroundMediaDefaults ?? null) ? $backgroundMediaDefaults : [];
+    $backgroundMediaAssetId = old('background_media_asset_id', $backgroundDefaults['asset_id'] ?? null);
+    $backgroundMediaVariantId = old('background_media_variant_id', $backgroundDefaults['variant_id'] ?? null);
+@endphp
 <input type="hidden" name="background_image" value="{{ old('background_image', $role->background_image) }}">
+<input type="hidden" name="background_media_asset_id" value="{{ $backgroundMediaAssetId ? (int) $backgroundMediaAssetId : '' }}">
+<input type="hidden" name="background_media_variant_id" value="{{ $backgroundMediaVariantId ? (int) $backgroundMediaVariantId : '' }}">
 <input type="hidden" name="accent_color" value="{{ old('accent_color', $role->accent_color) }}">
 <input type="hidden" name="font_color" value="{{ old('font_color', $role->font_color) }}">
 <input type="hidden" name="font_family" value="{{ old('font_family', $role->font_family) }}">


### PR DESCRIPTION
## Summary
- add a schedule background manager that imports the bundled images into the media library and exposes them for selection
- switch role creation and editing flows to default to media-library backed backgrounds and update the form preview logic
- adjust validation, guest layout rendering, and testing helpers to work with media library background selections

## Testing
- php artisan test --testsuite=Unit *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68fc42de61f8832eb81cb0eb7b02caea