### PR TITLE
Fix beta release prerelease flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
-          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+          prerelease: ${{ steps.version.outputs.prerelease }}
           title: "${{ steps.version.outputs.channel == 'beta' && 'Beta Release' || 'Latest Release' }}"
           automatic_release_tag: "${{ steps.version.outputs.version }}"
           files: |

--- a/tests/Unit/BumpVersionScriptTest.php
+++ b/tests/Unit/BumpVersionScriptTest.php
@@ -13,6 +13,7 @@ class BumpVersionScriptTest extends TestCase
     protected function tearDown(): void
     {
         putenv('BUMP_VERSION_DATE');
+        putenv('GITHUB_OUTPUT');
 
         parent::tearDown();
     }
@@ -50,5 +51,35 @@ class BumpVersionScriptTest extends TestCase
         putenv('BUMP_VERSION_DATE=20251024');
 
         $this->assertSame('20251024-01b', bumpVersion('5.0.17b', 'beta'));
+    }
+
+    public function testGithubOutputsMarkBetaReleasesAsPrereleases(): void
+    {
+        $outputFile = tempnam(sys_get_temp_dir(), 'gho_');
+
+        $this->assertIsString($outputFile);
+
+        putenv('GITHUB_OUTPUT=' . $outputFile);
+
+        writeGithubOutputs('20251024-01b', 'beta', false);
+
+        $this->assertStringContainsString('prerelease=true', (string) file_get_contents($outputFile));
+
+        @unlink($outputFile);
+    }
+
+    public function testGithubOutputsMarkProductionReleasesAsStable(): void
+    {
+        $outputFile = tempnam(sys_get_temp_dir(), 'gho_');
+
+        $this->assertIsString($outputFile);
+
+        putenv('GITHUB_OUTPUT=' . $outputFile);
+
+        writeGithubOutputs('20251024-01p', 'production', false);
+
+        $this->assertStringContainsString('prerelease=false', (string) file_get_contents($outputFile));
+
+        @unlink($outputFile);
     }
 }


### PR DESCRIPTION
## Summary
- pass the prerelease flag straight through from the version bump script so beta releases are marked correctly
- add unit coverage to ensure the GitHub outputs mark beta builds as prereleases and production builds as stable

## Testing
- not run (composer install requires authentication for GitHub packages in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68fc45f3ca94832ea0f030392a499fe5