### PR TITLE
Fix CLI version script warnings

### DIFF
--- a/scripts/bump-version.php
+++ b/scripts/bump-version.php
@@ -3,9 +3,6 @@
 
 declare(strict_types=1);
 
-use DateTimeImmutable;
-use DateTimeZone;
-
 const ALLOWED_CHANNELS = ['production', 'beta'];
 
 if (PHP_SAPI === 'cli' && realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
@@ -212,7 +209,7 @@ function resolveVersionDate(): string
         return $override;
     }
 
-    return (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format('Ymd');
+    return (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Ymd');
 }
 
 function validateVersionDate(string $date): bool


### PR DESCRIPTION
## Summary
- remove redundant DateTime imports that caused warnings in PHP 8.4
- reference DateTime classes with fully qualified names to keep the script warning-free

## Testing
- php scripts/bump-version.php beta

------
https://chatgpt.com/codex/tasks/task_e_68fc47aa6c10832eaa0096949d153aa7