### PR TITLE
Update release workflow to use gh release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,12 +86,12 @@ jobs:
           zip -r eventschedule.zip .
 
       - name: Create Release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
-          prerelease: ${{ steps.version.outputs.prerelease }}
-          title: "${{ steps.version.outputs.channel == 'beta' && 'Beta Release' || 'Latest Release' }}"
-          automatic_release_tag: "${{ steps.version.outputs.version }}"
+          prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+          name: "${{ steps.version.outputs.channel == 'beta' && 'Beta Release' || 'Latest Release' }}"
+          tag_name: "${{ steps.version.outputs.version }}"
           files: |
             eventschedule.zip


### PR DESCRIPTION
## Summary
- replace the deprecated automatic release action with softprops/action-gh-release
- configure the release metadata so beta builds are published as prereleases

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd40fea360832e97b278e240397608