### PR TITLE
ci: scope release latest flag by channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+          make_latest: ${{ steps.version.outputs.channel == 'beta' && 'legacy' || 'true' }}
           name: "${{ steps.version.outputs.channel == 'beta' && 'Beta Release' || 'Latest Release' }}"
           tag_name: "${{ steps.version.outputs.version }}"
           files: |


### PR DESCRIPTION
## Summary
- configure the release workflow to only mark production releases as the latest production build
- allow beta releases to keep GitHub's legacy behavior so they remain the latest prerelease instead of the latest production release

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd4344dbfc832e87423f59ab9cc455