### PR TITLE
Fix beta release latest flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
-          make_latest: ${{ steps.version.outputs.channel == 'beta' && 'legacy' || 'true' }}
+          # Always mark the generated release as the latest so beta builds update the
+          # "Latest" pre-release tag on GitHub instead of leaving the previous beta.
+          make_latest: true
           name: "${{ steps.version.outputs.channel == 'beta' && 'Beta Release' || 'Latest Release' }}"
           tag_name: "${{ steps.version.outputs.version }}"
           files: |


### PR DESCRIPTION
## Summary
- ensure the release workflow always marks generated releases as latest so beta builds update the pre-release tag on GitHub

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68fd49c74ddc832e9da710aad54f7999