### PR TITLE
Remove API plan gating and document endpoint behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@
 - 🚀 **Automatic App Updates:** Keep the platform up to date effortlessly with one-click automatic updates.
 - 🧭 **Streamlined Admin Navigation:** Reach Venues, Talent, and Curators from top-level menus while keeping their detailed sub-navigation intact.
 
+## API Reference
+
+Comprehensive request/response samples for every REST endpoint, including authentication and failure handling, are available in [docs/API_REFERENCE.md](docs/API_REFERENCE.md).
+
 <div style="display: flex; gap: 10px;">
     <img src="https://github.com/eventschedule/eventschedule/blob/main/public/images/screenshots/screen_1.png?raw=true" width="49%" alt="Guest > Schedule">
     <img src="https://github.com/eventschedule/eventschedule/blob/main/public/images/screenshots/screen_2.png?raw=true" width="49%" alt="Guest > Event">

--- a/app/Http/Controllers/Api/ApiEventController.php
+++ b/app/Http/Controllers/Api/ApiEventController.php
@@ -78,10 +78,6 @@ class ApiEventController extends Controller
             $request->merge(['members' => [$encodedRoleId => ['name' => $role->name]]]);
         }   
 
-        if (! $role->isPro()) {
-            return response()->json(['error' => 'API usage is limited to Pro accounts'], 403);
-        }
-
         if (! auth()->user()->isMember($subdomain)) {
             return response()->json(['error' => 'Unauthorized'], 403);
         }
@@ -230,10 +226,6 @@ class ApiEventController extends Controller
 
         if ($event->user_id !== auth()->id()) {
             return response()->json(['error' => 'Unauthorized'], 403);
-        }
-
-        if (! $event->isPro()) {
-            return response()->json(['error' => 'API usage is limited to Pro accounts'], 403);
         }
 
         if ($request->has('flyer_image_id')) {

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -663,29 +663,51 @@ class Role extends Model implements MustVerifyEmail
 
     public function toApiData()
     {
-        $data = new \stdClass;
+        $this->loadMissing(['groups']);
 
-        if (! $this->isPro()) {
-            return $data;
-        }
-
-        $data->id = UrlUtils::encodeId($this->id);
-        $data->url = $this->getGuestUrl();
-        $data->type = $this->type;
-        $data->name = $this->name;
-        $data->email = $this->email;
-        $data->website = $this->website;
-        $data->description = $this->description;
+        $data = [
+            'id' => UrlUtils::encodeId($this->id),
+            'url' => $this->getGuestUrl(),
+            'type' => $this->type,
+            'subdomain' => $this->subdomain,
+            'name' => $this->name,
+            'email' => $this->email,
+            'website' => $this->website,
+            'description' => $this->description,
+            'timezone' => $this->timezone,
+            'language_code' => $this->language_code,
+            'country_code' => $this->country_code,
+            'plan_type' => $this->plan_type,
+            'plan_expires' => $this->plan_expires,
+            'contacts' => $this->contacts,
+            'import_config' => $this->import_config,
+            'accept_requests' => (bool) $this->accept_requests,
+            'request_terms' => $this->request_terms,
+            'youtube_links' => $this->youtube_links ? json_decode($this->youtube_links, true) : [],
+            'groups' => $this->groups->map(function ($group) {
+                return [
+                    'id' => $group->encodeId(),
+                    'name' => $group->name,
+                    'name_en' => $group->name_en,
+                    'slug' => $group->slug,
+                ];
+            })->values()->all(),
+        ];
 
         if ($this->isVenue()) {
-            $data->address1 = $this->address1;
-            $data->city = $this->city;
-            $data->state = $this->state;
-            $data->postal_code = $this->postal_code;
-            $data->country_code = $this->country_code;
+            $data['address1'] = $this->address1;
+            $data['address2'] = $this->address2;
+            $data['city'] = $this->city;
+            $data['state'] = $this->state;
+            $data['postal_code'] = $this->postal_code;
+            $data['country_code'] = $this->country_code;
         }
-                
-        return $data;
+
+        if ($this->isTalent()) {
+            $data['youtube_url'] = $this->getFirstVideoUrl();
+        }
+
+        return (object) $data;
     }
 
     public function isPro()

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,196 @@
+# REST API Reference
+
+Event Schedule exposes a JSON API that mirrors the web application's scheduling, booking, and media features. All endpoints are now available to every account tier – no Pro subscription required – while still enforcing authentication and per-user authorization.
+
+## Authentication
+
+Provide the API key that is generated from **Settings → Integrations & API** with every request.
+
+```
+X-API-Key: <your-api-key>
+Accept: application/json
+Content-Type: application/json
+```
+
+### Rate limits & throttling
+
+* **Per IP:** 60 requests per minute (HTTP 429 when exceeded).
+* **Brute-force protection:** After 10 failed API key attempts the key is blocked for 15 minutes (HTTP 423).
+* **Missing or invalid key:** HTTP 401 with an `error` message.
+
+Example error payloads:
+
+```json
+{
+  "error": "API key is required"
+}
+```
+
+```json
+{
+  "error": "Invalid API key"
+}
+```
+
+## Schedules
+
+### `GET /api/schedules`
+Returns the authenticated user's venues, talents, curators, and other schedules.
+
+#### Successful response (200)
+```json
+{
+  "data": [
+    {
+      "id": "YmFzZTY0LWVuY29kZWQ=",
+      "url": "https://eventschedule.test/sample-venue",
+      "type": "venue",
+      "subdomain": "sample-venue",
+      "name": "Sample Venue",
+      "timezone": "UTC",
+      "groups": [
+        {"id": "R1JPVVAtMQ==", "name": "Main Stage", "slug": "main-stage"}
+      ],
+      "contacts": [
+        {"name": "Support", "email": "support@example.com", "phone": "+1234567890"}
+      ]
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "per_page": 100,
+    "total": 1,
+    "path": "https://eventschedule.test/api/schedules"
+  }
+}
+```
+
+#### Failure scenarios
+* **401** – Missing or invalid API key.
+* **423** – API key temporarily blocked after repeated failures.
+* **429** – IP-level rate limit exceeded.
+
+## Events
+
+### `GET /api/events`
+Lists all events owned by the authenticated user, including ticketing, scheduling, and media metadata.
+
+#### Successful response (200)
+```json
+{
+  "data": [
+    {
+      "id": "RVZFTlQtMQ==",
+      "name": "API Showcase",
+      "slug": "api-showcase",
+      "description": "Showcase description",
+      "description_html": "<p>Showcase description</p>",
+      "starts_at": "2024-01-01 20:00:00",
+      "duration": 120,
+      "timezone": "UTC",
+      "tickets_enabled": true,
+      "ticket_currency_code": "USD",
+      "tickets": [
+        {"id": "VElDS0VULTE=", "type": "General Admission", "price": 2500, "quantity": 100}
+      ],
+      "members": {
+        "Uk9MRS0y": {"name": "Performer", "email": null, "youtube_url": null}
+      },
+      "schedules": [
+        {"id": "Uk9MRS0y", "name": "Performer", "type": "talent"},
+        {"id": "Uk9MRS0z", "name": "The Club", "type": "venue"}
+      ],
+      "venue": {
+        "id": "Uk9MRS0z",
+        "type": "venue",
+        "name": "The Club",
+        "address1": null,
+        "city": null
+      },
+      "flyer_image_url": "https://eventschedule.test/storage/flyers/api-showcase.png",
+      "registration_url": "https://events.example.com/register",
+      "event_url": "https://events.example.com/stream",
+      "payment_method": null,
+      "payment_instructions": "Pay at the door",
+      "ticket_notes": "Bring your ticket"
+    }
+  ],
+  "meta": {
+    "current_page": 1,
+    "per_page": 100,
+    "total": 1
+  }
+}
+```
+
+#### Failure scenarios
+* **401 / 423 / 429** – Same authentication and throttling responses as `/api/schedules`.
+
+### `POST /api/events/{subdomain}`
+Creates a new event attached to the provided schedule (talent, venue, or curator subdomain).
+
+#### Required fields
+* `name` – string
+* `starts_at` – `Y-m-d H:i:s`
+* At least one of `venue_id`, `venue_address1`, or `event_url`
+
+Optional fields include `members`, `schedule` (sub-schedule slug), `category`, ticketing fields, payment instructions, etc. Category names are resolved automatically when `category_name` is supplied.
+
+#### Successful response (201)
+```json
+{
+  "data": {
+    "id": "RVZFTlQtMg==",
+    "name": "API Created Event",
+    "starts_at": "2024-03-15 19:00:00",
+    "tickets_enabled": false,
+    "members": {
+      "Uk9MRS0y": {"name": "Performer", "email": null, "youtube_url": null}
+    }
+  },
+  "meta": {
+    "message": "Event created successfully"
+  }
+}
+```
+
+#### Failure scenarios
+* **401** – Missing API key.
+* **403** – Authenticated user does not belong to the targeted subdomain.
+* **404** – Schedule subdomain not found.
+* **422** – Validation errors (invalid dates, missing venue details, unknown categories, etc.).
+
+### `POST /api/events/flyer/{event_id}`
+Uploads or swaps the flyer for an event you own. Supply either a multipart `flyer_image` file or a JSON payload containing `flyer_image_id` to reuse an existing upload.
+
+#### Successful response (200)
+```json
+{
+  "data": {
+    "id": "RVZFTlQtMQ==",
+    "flyer_image_url": "https://eventschedule.test/storage/flyers/api-showcase.png"
+  },
+  "meta": {
+    "message": "Flyer uploaded successfully"
+  }
+}
+```
+
+#### Failure scenarios
+* **401** – Missing API key.
+* **403** – Event does not belong to the authenticated user.
+* **404** – Event ID not found.
+* **422** – Validation error (e.g., invalid `flyer_image_id`).
+
+## Error handling summary
+
+| Status | Reason | Payload |
+| ------ | ------ | ------- |
+| 401 | Missing or invalid `X-API-Key` | `{ "error": "API key is required" }` or `{ "error": "Invalid API key" }` |
+| 403 | User is not authorized for the requested resource | `{ "error": "Unauthorized" }` |
+| 404 | Resource not found | `{ "message": "Not Found" }` |
+| 422 | Validation failure | Standard Laravel validation error bag |
+| 423 | API key temporarily blocked | `{ "error": "API key temporarily blocked" }` |
+| 429 | Rate limit exceeded | `{ "error": "Rate limit exceeded" }` |
+
+With these responses and the expanded payloads, every feature that is exposed in the Event Schedule UI—schedules, talent assignments, venue details, ticketing, payments, and media—can now be queried or created via the public REST API across all plan levels.

--- a/tests/Unit/ApiDataTest.php
+++ b/tests/Unit/ApiDataTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Event;
+use App\Models\Group;
+use App\Models\Role;
+use App\Models\Ticket;
+use App\Utils\UrlUtils;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class ApiDataTest extends TestCase
+{
+    public function test_role_to_api_data_is_populated_for_non_pro_accounts(): void
+    {
+        $role = new Role([
+            'type' => 'venue',
+            'name' => 'Sample Venue',
+            'email' => 'venue@example.com',
+            'website' => 'https://venue.example.com',
+            'description' => 'A description',
+            'timezone' => 'UTC',
+            'language_code' => 'en',
+            'country_code' => 'US',
+            'accept_requests' => true,
+            'request_terms' => 'Be kind',
+        ]);
+
+        $role->id = 1;
+        $role->subdomain = 'sample-venue';
+        $role->plan_type = 'starter';
+        $role->plan_expires = Carbon::now()->addMonth()->format('Y-m-d');
+        $role->contacts = [
+            ['name' => 'Support', 'email' => 'support@example.com', 'phone' => '+1234567890'],
+        ];
+        $role->youtube_links = json_encode([
+            ['name' => 'Intro', 'url' => 'https://youtube.com/watch?v=123', 'thumbnail_url' => ''],
+        ]);
+
+        $group = new Group([
+            'name' => 'Main Stage',
+            'slug' => 'main-stage',
+        ]);
+        $group->id = 10;
+
+        $role->setRelation('groups', new Collection([$group]));
+
+        $data = $role->toApiData();
+
+        $this->assertSame(UrlUtils::encodeId(1), $data->id);
+        $this->assertSame('sample-venue', $data->subdomain);
+        $this->assertTrue($data->accept_requests);
+        $this->assertCount(1, $data->groups);
+        $this->assertSame('Main Stage', $data->groups[0]['name']);
+    }
+
+    public function test_event_to_api_data_includes_members_and_tickets_for_all_plans(): void
+    {
+        $talent = new Role([
+            'type' => 'talent',
+            'name' => 'Performer',
+        ]);
+        $talent->id = 2;
+        $talent->subdomain = 'performer';
+        $talent->timezone = 'UTC';
+        $talent->plan_type = 'starter';
+        $talent->plan_expires = Carbon::now()->addMonth()->format('Y-m-d');
+        $talent->setRelation('groups', new Collection());
+
+        $venue = new Role([
+            'type' => 'venue',
+            'name' => 'The Club',
+        ]);
+        $venue->id = 3;
+        $venue->subdomain = 'the-club';
+        $venue->timezone = 'UTC';
+        $venue->plan_type = 'starter';
+        $venue->plan_expires = Carbon::now()->addMonth()->format('Y-m-d');
+        $venue->setRelation('groups', new Collection());
+
+        $event = new Event([
+            'name' => 'API Showcase',
+            'slug' => 'api-showcase',
+            'description' => 'Showcase description',
+            'starts_at' => '2024-01-01 20:00:00',
+            'duration' => 120,
+            'tickets_enabled' => true,
+            'ticket_currency_code' => 'USD',
+            'total_tickets_mode' => 'separate',
+            'registration_url' => 'https://events.example.com/register',
+            'event_url' => 'https://events.example.com/stream',
+            'ticket_notes' => 'Bring your ticket',
+            'payment_instructions' => 'Pay at the door',
+        ]);
+
+        $event->id = 5;
+        $event->ticket_notes_html = '<p>Bring your ticket</p>';
+        $event->payment_instructions_html = '<p>Pay at the door</p>';
+        $event->flyer_image_url = 'flyers/api-showcase.png';
+
+        $ticket = new Ticket([
+            'type' => 'General Admission',
+            'price' => 2500,
+            'quantity' => 100,
+            'description' => 'Floor access',
+        ]);
+        $ticket->id = 7;
+        $ticket->event_id = 5;
+
+        $event->setRelation('tickets', new Collection([$ticket]));
+        $event->setRelation('roles', new Collection([$talent, $venue]));
+        $event->setRelation('flyerImage', null);
+        $event->setRelation('eventType', null);
+        $event->setRelation('creatorRole', $talent);
+
+        $data = $event->toApiData();
+
+        $this->assertSame(UrlUtils::encodeId(5), $data->id);
+        $this->assertSame('API Showcase', $data->name);
+        $this->assertSame('UTC', $data->timezone);
+        $this->assertTrue($data->tickets_enabled);
+        $this->assertCount(1, $data->tickets);
+        $this->assertArrayHasKey(UrlUtils::encodeId(2), $data->members);
+        $this->assertCount(2, $data->schedules);
+        $this->assertNull($data->curator_role);
+    }
+}


### PR DESCRIPTION
## Summary
- remove the Pro-plan restriction from API event endpoints so every account tier can use them
- expose ticketing, scheduling, and media metadata in API payloads for events and schedules
- document the API happy paths and error responses and cover the new behavior with unit tests

## Testing
- php artisan test --testsuite=Unit *(fails: vendor dependencies unavailable; composer install blocked by 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68fd4af2ae58832e85d45f7ecf8abc75