### PR TITLE
Fix event form validation when saving

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -1598,7 +1598,10 @@
         this.event.slug = sanitizedSlug || null;
 
         if (! this.isFormValid) {
-          event.preventDefault();
+          if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+          }
+
           alert("{{ __('messages.please_select_venue_or_participant') }}");
         }
       },
@@ -1713,10 +1716,11 @@
           .filter(member => !selectedIds.has(member.id));
       },
       isFormValid() {
-        var hasSubdomain = this.venueName || this.sanitizedSelectedMembers.length > 0;
-        var hasVenue = this.venueAddress1 || this.event.event_url;
+        const hasVenueSelection = !!this.selectedVenue || !!this.venueName;
+        const hasParticipants = this.sanitizedSelectedMembers.length > 0;
+        const hasLocationDetails = !!this.venueAddress1 || !!this.event.event_url;
 
-        return hasSubdomain && hasVenue;
+        return (hasVenueSelection || hasParticipants) && hasLocationDetails;
       },
       hasLimitedPaidTickets() {
         return this.tickets.some(ticket => ticket.price > 0 && ticket.quantity > 0);


### PR DESCRIPTION
## Summary
- ensure the event creation form treats a selected venue without a name as a valid selection
- guard the client-side validation from throwing when the browser event object is unavailable

## Testing
- composer install --no-interaction *(fails: network 403 while downloading from api.github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68feb8f96550832e9f48a725866e4ef5