### PR TITLE
Secure OpenSSL passphrase handling

### DIFF
--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -526,12 +526,13 @@ class AppleWalletService
         $command[] = '-passout';
         $command[] = 'pass:';
         $command[] = '-passin';
-        $command[] = 'pass:' . $password;
+        $command[] = 'fd:3';
 
         $descriptorSpec = [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
             2 => ['pipe', 'w'],
+            3 => ['pipe', 'w'],
         ];
 
         $process = @proc_open($command, $descriptorSpec, $pipes);
@@ -542,6 +543,8 @@ class AppleWalletService
             return null;
         }
 
+        fwrite($pipes[3], $password . PHP_EOL);
+        fclose($pipes[3]);
         fclose($pipes[0]);
         $stdout = stream_get_contents($pipes[1]) ?: '';
         fclose($pipes[1]);


### PR DESCRIPTION
## Summary
- avoid leaking the PKCS#12 password in process arguments when using the OpenSSL CLI fallback
- feed the password to OpenSSL through a dedicated pipe file descriptor instead of `-passin pass:`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fecb8451fc832eb0bfd29d9577917a