### PR TITLE
Fix OpenSSL CLI descriptor for passphrase input

### DIFF
--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -532,7 +532,7 @@ class AppleWalletService
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
             2 => ['pipe', 'w'],
-            3 => ['pipe', 'w'],
+            3 => ['pipe', 'r'],
         ];
 
         $process = @proc_open($command, $descriptorSpec, $pipes);


### PR DESCRIPTION
## Summary
- adjust the OpenSSL CLI descriptor so the passphrase pipe is opened for reading by the child process
- ensure the parent process can write the password and the CLI fallback succeeds when extracting certificates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fecec4b2d0832e9441e8ccd5dbf00c