### PR TITLE
Add Safari-friendly headers to Apple Wallet download

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -536,6 +536,10 @@ class TicketController extends Controller
         return response($pass, 200, [
             'Content-Type' => 'application/vnd.apple.pkpass',
             'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+            'Content-Transfer-Encoding' => 'binary',
+            'Content-Length' => strlen($pass),
+            'Cache-Control' => 'no-store, no-cache, must-revalidate',
+            'Pragma' => 'no-cache',
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add explicit binary download headers to the Apple Wallet ticket response so Safari recognizes the pass

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fed39472ec832e85ddd19e740fa9c5