### PR TITLE
Fix Apple Wallet pass asset dimensions

### DIFF
--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -81,10 +81,10 @@ class AppleWalletService
 
         $baseFiles = [
             'pass.json' => $this->encodeJson($payload),
-            'icon.png' => $this->createIcon($sale->event, 58),
-            'icon@2x.png' => $this->createIcon($sale->event, 116),
-            'logo.png' => $this->createIcon($sale->event, 160),
-            'logo@2x.png' => $this->createIcon($sale->event, 320),
+            'icon.png' => $this->createPassImage($sale->event, 58, 58),
+            'icon@2x.png' => $this->createPassImage($sale->event, 116, 116),
+            'logo.png' => $this->createPassImage($sale->event, 160, 50),
+            'logo@2x.png' => $this->createPassImage($sale->event, 320, 100),
         ];
 
         $manifest = $this->createManifest($baseFiles);
@@ -764,19 +764,22 @@ class AppleWalletService
         return $binary;
     }
 
-    protected function createIcon(Event $event, int $size): string
+    /**
+     * Generate a solid colour PNG asset that matches Apple's required dimensions.
+     */
+    protected function createPassImage(Event $event, int $width, int $height): string
     {
-        $image = imagecreatetruecolor($size, $size);
+        $image = imagecreatetruecolor($width, $height);
 
         if (! $image) {
-            throw new RuntimeException('Unable to create wallet icon image.');
+            throw new RuntimeException('Unable to create wallet image asset.');
         }
 
         imagealphablending($image, true);
         imagesavealpha($image, true);
 
         $background = $this->allocateColor($image, $event->creatorRole?->accent_color ?? '#4E81FA');
-        imagefilledrectangle($image, 0, 0, $size, $size, $background);
+        imagefilledrectangle($image, 0, 0, $width, $height, $background);
 
         $textColor = imagecolorallocatealpha($image, 255, 255, 255, 40);
         $initials = $this->resolveInitials($event);
@@ -784,8 +787,8 @@ class AppleWalletService
         $font = 5;
         $textWidth = imagefontwidth($font) * strlen($initials);
         $textHeight = imagefontheight($font);
-        $x = (int) max(0, ($size - $textWidth) / 2);
-        $y = (int) max(0, ($size - $textHeight) / 2);
+        $x = (int) max(0, ($width - $textWidth) / 2);
+        $y = (int) max(0, ($height - $textHeight) / 2);
 
         imagestring($image, $font, $x, $y, $initials, $textColor);
 

--- a/tests/Unit/Services/Wallet/AppleWalletServiceTest.php
+++ b/tests/Unit/Services/Wallet/AppleWalletServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services\Wallet;
 
+use App\Models\Event;
 use App\Services\Wallet\AppleWalletService;
 use Tests\TestCase;
 
@@ -19,6 +20,26 @@ class AppleWalletServiceTest extends TestCase
 
         $this->assertNotEmpty($certificates['cert'] ?? null);
         $this->assertNotEmpty($certificates['pkey'] ?? null);
+    }
+
+    public function testItGeneratesWalletAssetsWithExpectedDimensions(): void
+    {
+        $event = new Event(['name' => 'Sample Event']);
+        $service = $this->makeService(null);
+
+        $icon = $service->exposeCreatePassImage($event, 58, 58);
+        $iconImage = imagecreatefromstring($icon);
+        $this->assertNotFalse($iconImage, 'Icon PNG is invalid.');
+        $this->assertSame(58, imagesx($iconImage));
+        $this->assertSame(58, imagesy($iconImage));
+        imagedestroy($iconImage);
+
+        $logo = $service->exposeCreatePassImage($event, 160, 50);
+        $logoImage = imagecreatefromstring($logo);
+        $this->assertNotFalse($logoImage, 'Logo PNG is invalid.');
+        $this->assertSame(160, imagesx($logoImage));
+        $this->assertSame(50, imagesy($logoImage));
+        imagedestroy($logoImage);
     }
 
     protected function makeService(?string $password): AppleWalletServiceForTests
@@ -60,5 +81,10 @@ class AppleWalletServiceForTests extends AppleWalletService
     public function exposeLoadCertificates(string $contents): array
     {
         return $this->loadCertificates($contents);
+    }
+
+    public function exposeCreatePassImage(Event $event, int $width, int $height): string
+    {
+        return $this->createPassImage($event, $width, $height);
     }
 }


### PR DESCRIPTION
## Summary
- ensure generated Apple Wallet icons and logos use Apple’s required dimensions
- add a regression test that verifies the PNG assets match the expected sizes

## Testing
- php -l app/Services/Wallet/AppleWalletService.php
- php -l tests/Unit/Services/Wallet/AppleWalletServiceTest.php
- composer install --no-interaction --prefer-dist *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ff6e61cea4832ead1e570a73341471