### PR TITLE
Handle Apple Wallet signer chains in service

### DIFF
--- a/docs/APPLE_WALLET_PASS_SETUP.md
+++ b/docs/APPLE_WALLET_PASS_SETUP.md
@@ -24,8 +24,9 @@ Apple Wallet passes must be signed with a certificate generated for your Pass Ty
 > **Tip:** Convert the `.p12` file into a PEM pair if your deployment environment requires it:
 >
 > ```bash
-> openssl pkcs12 -in Certificates.p12 -out PassCertificate.pem -clcerts -nokeys
-> openssl pkcs12 -in Certificates.p12 -out PassKey.pem -nocerts -nodes
+> # OpenSSL 3 (macOS 12+/Homebrew) requires the `-legacy` flag for RC2-encrypted bundles
+> openssl pkcs12 -in Certificates.p12 -out PassCertificate.pem -clcerts -nokeys -legacy
+> openssl pkcs12 -in Certificates.p12 -out PassKey.pem -nocerts -nodes -legacy
 > ```
 
 ## 3. Prepare Pass Assets

--- a/docs/APPLE_WALLET_TESTING_CHECKLIST.md
+++ b/docs/APPLE_WALLET_TESTING_CHECKLIST.md
@@ -45,12 +45,16 @@ Use this checklist after deploying a build that touches Apple Wallet signing or 
    unzip -p test.pkpass signature > signature
    unzip -p test.pkpass manifest.json > manifest.json
    ```
-2. Verify the detached signature with OpenSSL (requires the WWDR intermediate and Apple Root CA):
+2. Verify the detached signature with OpenSSL. Concatenate your pass certificate with the WWDR intermediate first so OpenSSL can locate the signer:
+   ```bash
+   cat /path/to/PassCertificate.pem /path/to/WWDR.pem > /path/to/pass_chain.pem
+   ```
+   Then run the verification (requires the WWDR intermediate and Apple Root CA):
    ```bash
    openssl smime -verify -inform DER \
      -in signature \
      -content manifest.json \
-     -certfile /path/to/WWDR.pem \
+     -certfile /path/to/pass_chain.pem \
      -CAfile /path/to/AppleRootCA.pem \
      -nointern -noverify > /dev/null
    ```


### PR DESCRIPTION
## Summary
- build a signer certificate chain before signing Apple Wallet manifests and reuse it for both CMS and PKCS#7 flows
- add helpers to export certificate material, normalize extracerts, and deduplicate chain entries while incorporating the WWDR intermediate
- expand unit coverage to expose the chain builder and ensure loaded certificates return the expected metadata

## Testing
- php -l app/Services/Wallet/AppleWalletService.php
- php -l tests/Unit/Services/Wallet/AppleWalletServiceTest.php
- composer install --no-interaction *(fails: GitHub CONNECT tunnel 403 while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ff973b911c832e9043b60afabf39a5