### PR TITLE
Relax Apple wallet config sanitizer input typing

### DIFF
--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -60,7 +60,10 @@ class AppleWalletService
         return true;
     }
 
-    protected function sanitizeConfigValue(?string $value): ?string
+    /**
+     * @param  mixed  $value
+     */
+    protected function sanitizeConfigValue($value): ?string
     {
         if (! is_string($value)) {
             return null;


### PR DESCRIPTION
## Summary
- allow Apple wallet config sanitizer to accept mixed input so non-string values are handled gracefully

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffac4cbe0c832e8be3057b87ccee81