### PR TITLE
Add configurable Apple Wallet debugging logs

### DIFF
--- a/config/wallet.php
+++ b/config/wallet.php
@@ -12,6 +12,8 @@ return [
         'background_color' => env('APPLE_WALLET_BACKGROUND_COLOR', 'rgb(78,129,250)'),
         'foreground_color' => env('APPLE_WALLET_FOREGROUND_COLOR', 'rgb(255,255,255)'),
         'label_color' => env('APPLE_WALLET_LABEL_COLOR', 'rgb(255,255,255)'),
+        'debug' => env('APPLE_WALLET_DEBUG', env('APP_DEBUG', false)),
+        'log_channel' => env('APPLE_WALLET_LOG_CHANNEL'),
     ],
 
     'google' => [

--- a/docs/APPLE_WALLET_TESTING_CHECKLIST.md
+++ b/docs/APPLE_WALLET_TESTING_CHECKLIST.md
@@ -7,6 +7,7 @@ Use this checklist after deploying a build that touches Apple Wallet signing or 
 1. **Confirm configuration**
    - `php artisan tinker --execute="dump(config('wallet.apple'))"` to ensure the pass type identifier, team identifier, certificate paths, and password values are present.
    - On the server, verify the referenced certificate files exist and have the correct permissions (`ls -l /path/to/certs`).
+   - (Optional) Enable verbose logging by setting `APPLE_WALLET_DEBUG=true` (and optionally `APPLE_WALLET_LOG_CHANNEL=<channel>`). Review `storage/logs/laravel.log` or the configured channel while exercising the flow.
 2. **Clear cache** (if you changed configuration):
    ```bash
    php artisan config:clear


### PR DESCRIPTION
## Summary
- add configurable debug and log channel settings for the Apple Wallet integration
- instrument AppleWalletService with granular debug logging around configuration, certificate parsing, and manifest signing
- document how to enable the new debug logging in the Apple Wallet testing checklist

## Testing
- php -l app/Services/Wallet/AppleWalletService.php

------
https://chatgpt.com/codex/tasks/task_e_68ffb219bdb4832eb8885f3fab292548