### PR TITLE
Fix Apple Wallet signer chain to exclude primary certificate

### DIFF
--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -679,13 +679,17 @@ class AppleWalletService
         $chain = [];
         $fingerprints = [];
 
-        $primary = $this->exportCertificateToPem($certificates['cert'] ?? null);
+        $primaryPem = $this->exportCertificateToPem($certificates['cert'] ?? null);
 
-        if ($primary === null) {
+        if ($primaryPem === null) {
             return null;
         }
 
-        $this->appendCertificateToChain($chain, $fingerprints, $primary);
+        $primaryFingerprint = preg_replace('/\s+/', '', $primaryPem) ?? '';
+
+        if ($primaryFingerprint !== '') {
+            $fingerprints[sha1($primaryFingerprint)] = true;
+        }
 
         foreach ($certificates['extracerts'] as $extra) {
             $pem = $this->exportCertificateToPem($extra);


### PR DESCRIPTION
## Summary
- skip re-adding the primary pass certificate when assembling the signer chain file used for manifest signing
- keep duplicate filtering by registering the primary certificate fingerprint before processing intermediates and WWDR certificates

## Testing
- php -l app/Services/Wallet/AppleWalletService.php

------
https://chatgpt.com/codex/tasks/task_e_68ffbd39b8f0832e9351a845c4a386f6