### PR TITLE
Fix Apple Wallet pass download response

### DIFF
--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -535,20 +535,14 @@ class TicketController extends Controller
 
         $passLength = strlen($pass);
 
-        return response()->streamDownload(
-            static function () use ($pass): void {
-                echo $pass;
-            },
-            $filename,
-            [
-                'Content-Type' => 'application/vnd.apple.pkpass',
-                'Content-Disposition' => 'attachment; filename="' . $filename . '"',
-                'Content-Transfer-Encoding' => 'binary',
-                'Cache-Control' => 'no-store, no-cache, must-revalidate',
-                'Pragma' => 'no-cache',
-                'Content-Length' => (string) $passLength,
-            ]
-        );
+        return response($pass, 200, [
+            'Content-Type' => 'application/vnd.apple.pkpass',
+            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+            'Content-Transfer-Encoding' => 'binary',
+            'Cache-Control' => 'no-store, no-cache, must-revalidate',
+            'Pragma' => 'no-cache',
+            'Content-Length' => (string) $passLength,
+        ]);
     }
 
     public function googleWallet($eventId, $secret, GoogleWalletService $googleWalletService)


### PR DESCRIPTION
## Summary
- return Apple Wallet pass downloads with a standard binary response instead of a streamed callback to avoid chunked transfer issues

## Testing
- Not run (Composer install requires GitHub credentials in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ffcc5e416c832ead482fe16dcb5840