### PR TITLE
Add extensive Apple Wallet debug instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Event Schedule can generate Apple Wallet passes and Google Wallet tickets for pa
 3. Download the latest Apple WWDR certificate and set `APPLE_WALLET_WWDR_CERTIFICATE_PATH` to its location.
 4. Specify your Pass Type Identifier (`APPLE_WALLET_PASS_TYPE_IDENTIFIER`) and Apple Developer Team ID (`APPLE_WALLET_TEAM_IDENTIFIER`).
 5. Optionally customize the organization name and colors with the remaining `APPLE_WALLET_*` variables.
+6. When debugging, set `APPLE_WALLET_DEBUG=true` and (optionally) `APPLE_WALLET_DEBUG_DUMP_PATH` to capture per-sale pass artifacts on disk.
 
 ### Google Wallet
 

--- a/config/wallet.php
+++ b/config/wallet.php
@@ -14,6 +14,7 @@ return [
         'label_color' => env('APPLE_WALLET_LABEL_COLOR', 'rgb(255,255,255)'),
         'debug' => env('APPLE_WALLET_DEBUG', env('APP_DEBUG', false)),
         'log_channel' => env('APPLE_WALLET_LOG_CHANNEL'),
+        'debug_dump_path' => env('APPLE_WALLET_DEBUG_DUMP_PATH', storage_path('app/wallet/debug-dumps')),
     ],
 
     'google' => [


### PR DESCRIPTION
## Summary
- expand Apple Wallet pass generation logging with sale context, payload summaries, and signature metrics
- persist debug artifacts (payload, assets, manifest, signature, package, metadata) to a configurable directory when wallet debugging is enabled
- add the APPLE_WALLET_DEBUG_DUMP_PATH option to wallet configuration and document how to enable detailed dumps in the README

## Testing
- ./vendor/bin/phpunit --filter AppleWalletServiceTest *(fails: vendor binary missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ffcf615b90832e80d0f044fff5c815