### PR TITLE
Handle base64 Apple Wallet certificates

### DIFF
--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -903,14 +903,22 @@ class AppleWalletService
 
             $parsed = @openssl_x509_read($certificate);
 
-            if ($parsed === false) {
-                return null;
+            if ($parsed !== false) {
+                $exported = '';
+
+                if (@openssl_x509_export($parsed, $exported)) {
+                    return trim($exported);
+                }
             }
 
-            $exported = '';
+            $maybeBase64 = preg_replace('/\s+/', '', $trimmed) ?? '';
 
-            if (@openssl_x509_export($parsed, $exported)) {
-                return trim($exported);
+            if ($maybeBase64 !== '') {
+                $decoded = base64_decode($maybeBase64, true);
+
+                if ($decoded !== false && $decoded !== '') {
+                    return $this->exportCertificateToPem($decoded);
+                }
             }
 
             return null;

--- a/tests/Unit/Services/Wallet/AppleWalletServiceTest.php
+++ b/tests/Unit/Services/Wallet/AppleWalletServiceTest.php
@@ -27,6 +27,21 @@ class AppleWalletServiceTest extends TestCase
         $this->assertIsArray($certificates['extracerts'] ?? null);
     }
 
+    public function testItParsesBase64EncodedCertificatesIntoPem(): void
+    {
+        $service = $this->makeService(null);
+        $pem = $this->generateStandaloneCertificatePem();
+        $base64 = preg_replace('/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s+/', '', $pem) ?? '';
+
+        $this->assertNotSame('', $base64, 'Base64 certificate contents should not be empty.');
+
+        $converted = $service->exposeExportCertificateToPem($base64);
+
+        $this->assertNotNull($converted, 'Base64 encoded certificate should be converted to PEM.');
+        $this->assertIsString($converted, 'Converted certificate should be represented as a PEM string.');
+        $this->assertSame(trim($pem), trim($converted), 'Converted certificate should match original PEM.');
+    }
+
     public function testItConsidersTrimmedConfigurationValuesWhenCheckingAvailability(): void
     {
         $original = config('wallet.apple');
@@ -465,6 +480,11 @@ class AppleWalletServiceForTests extends AppleWalletService
     public function exposeCreateSignerCertificateChainFile(array $certificates): ?string
     {
         return $this->createSignerCertificateChainFile($certificates);
+    }
+
+    public function exposeExportCertificateToPem(string $certificate): ?string
+    {
+        return $this->exportCertificateToPem($certificate);
     }
 
     public function exposeParsePemCertificateBundle(string $contents, string $password): ?array


### PR DESCRIPTION
## Summary
- add a base64 decoding fallback when exporting Apple Wallet certificates so WWDR files stored as raw base64 can be parsed
- expose certificate export helper in the test double and add coverage for base64-only inputs

## Testing
- php -l app/Services/Wallet/AppleWalletService.php
- php -l tests/Unit/Services/Wallet/AppleWalletServiceTest.php

------
https://chatgpt.com/codex/tasks/task_e_68ffd6512878832e8f15c0d4a4edc0b5