### PR TITLE
Normalize WWDR certificate before signing passes

### DIFF
--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -589,11 +589,17 @@ class AppleWalletService
         if ($chainPath === null && $this->wwdrCertificatePath !== null) {
             $normalizedWwdrPath = $this->createTemporaryPemCertificateFromPath($this->wwdrCertificatePath);
 
-            if ($normalizedWwdrPath !== null) {
-                $this->logDebug('Using normalized WWDR certificate for manifest signing.', [
-                    'chain_path' => $normalizedWwdrPath,
+            if ($normalizedWwdrPath === null) {
+                $this->logDebug('Failed to normalize WWDR certificate for manifest signing.', [
+                    'source_path' => $this->wwdrCertificatePath,
                 ]);
+
+                throw new RuntimeException('Unable to normalize WWDR certificate for manifest signing.');
             }
+
+            $this->logDebug('Using normalized WWDR certificate for manifest signing.', [
+                'chain_path' => $normalizedWwdrPath,
+            ]);
         }
 
         $this->logDebug('Generated manifest signing workspace.', [


### PR DESCRIPTION
## Summary
- normalize the configured WWDR certificate to PEM when no signer chain is produced
- reuse the normalized certificate when invoking CMS and PKCS#7 signing helpers
- add debug logging and cleanup for the temporary PEM certificate file

## Testing
- `composer test` *(fails: Command "test" is not defined.)*
- `php vendor/bin/phpunit` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68ffe07b787c832eb94861fc01b92ab8