### PR TITLE
Allow editing events with incomplete venue details

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -1597,7 +1597,7 @@
         this.eventSlug = sanitizedSlug;
         this.event.slug = sanitizedSlug || null;
 
-        if (! this.isFormValid) {
+        if (! this.event.id && ! this.isFormValid) {
           if (event && typeof event.preventDefault === 'function') {
             event.preventDefault();
           }


### PR DESCRIPTION
## Summary
- prevent the front-end venue/participant validation from blocking updates to existing events
- keep the slug sanitization in place while letting the browser submit the form during edits

## Testing
- php artisan test *(fails: missing `vendor/autoload.php`)*

------
https://chatgpt.com/codex/tasks/task_e_6900150b6774832e841c2517cc86b71a