### PR TITLE
Fix ticket price formatting when editing events

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -1181,6 +1181,29 @@
     });
   }
 
+  const formatTicketPrice = value => {
+    if (value === null || typeof value === 'undefined' || value === '') {
+      return '';
+    }
+
+    if (typeof value === 'string') {
+      const normalized = value.replace(/,/g, '');
+      const numeric = Number(normalized);
+
+      if (Number.isFinite(numeric)) {
+        return numeric.toFixed(2);
+      }
+
+      return '';
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value.toFixed(2);
+    }
+
+    return '';
+  };
+
   const vueApp = createApp({
     data() {
       return {
@@ -1223,17 +1246,7 @@
         eventUrlBaseAbsolute: @json($absoluteEventUrlBase),
         tickets: @json($event->tickets ?? [new Ticket()]).map(ticket => ({
           ...ticket,
-          /*
-          price: new Intl.NumberFormat('{{ app()->getLocale() }}', {
-            style: 'currency',
-            currency: '{{ $event->ticket_currency_code ?? "USD" }}'
-          }).format(ticket.price).toString().replace(/[^\d.,]/g, '')         
-          */
-         price: new Intl.NumberFormat('{{ app()->getLocale() }}', {
-            style: 'decimal',
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
-          }).format(ticket.price)
+          price: formatTicketPrice(ticket.price)
         })),
         showExpireUnpaid: @json($event->expire_unpaid_tickets > 0),
         soldLabel: "{{ __('messages.sold_reserved') }}",
@@ -1593,6 +1606,11 @@
         return preferences;
       },
       validateForm(event) {
+        this.tickets = this.tickets.map(ticket => ({
+          ...ticket,
+          price: formatTicketPrice(ticket.price)
+        }));
+
         const sanitizedSlug = this.slugify(this.eventSlug);
         this.eventSlug = sanitizedSlug;
         this.event.slug = sanitizedSlug || null;


### PR DESCRIPTION
## Summary
- normalize ticket price values in the edit event form to avoid locale-specific thousand separators
- resanitize ticket prices before submit to keep browser validation happy while editing existing events

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_69001776cee4832ebea4eb45dff0d7b1