### PR TITLE
Ensure event edits submit after Vue state updates

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -1606,6 +1606,10 @@
         return preferences;
       },
       validateForm(event) {
+        const formElement = event && event.target instanceof HTMLFormElement
+          ? event.target
+          : null;
+
         this.tickets = this.tickets.map(ticket => ({
           ...ticket,
           price: formatTicketPrice(ticket.price)
@@ -1621,6 +1625,18 @@
           }
 
           alert("{{ __('messages.please_select_venue_or_participant') }}");
+
+          return;
+        }
+
+        if (event && typeof event.preventDefault === 'function') {
+          event.preventDefault();
+
+          this.$nextTick(() => {
+            if (formElement) {
+              formElement.submit();
+            }
+          });
         }
       },
       addTicket() {


### PR DESCRIPTION
## Summary
- prevent the event edit form from submitting until Vue normalizes ticket prices so updates persist when saving
- resubmit the form on the next tick after sanitizing values while preserving the existing new-event validation guard

## Testing
- not run (composer install requires a GitHub token in this environment)

------
https://chatgpt.com/codex/tasks/task_e_69001b2d733c832e8d9e97d6089434ad