### PR TITLE
Fix event update validation and enhance logging

### DIFF
--- a/app/Http/Requests/EventUpdateRequest.php
+++ b/app/Http/Requests/EventUpdateRequest.php
@@ -16,6 +16,23 @@ class EventUpdateRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'flyer_media_asset_id' => $this->normalizeNullableInteger($this->input('flyer_media_asset_id')),
+            'flyer_media_variant_id' => $this->normalizeNullableInteger($this->input('flyer_media_variant_id')),
+        ]);
+    }
+
+    protected function normalizeNullableInteger($value)
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return is_numeric($value) ? (int) $value : $value;
+    }
+
     /**
      * Get the validation rules that apply to the request.
      *


### PR DESCRIPTION
## Summary
- normalize optional media asset identifiers before validation so empty values do not fail integer checks
- add detailed logging throughout the event update workflow to capture authorization, save results, and redirects

## Testing
- ⚠️ `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6900c8536f44832e875ab60367b61448