### PR TITLE
Adjust venue selection validation visibility

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -1834,10 +1834,14 @@
 
         this.event.slug = newValue || null;
       },
-      venueType() {
+      venueType(newValue) {
         this.venueEmail = "";
         this.venueSearchEmail = "";
         this.venueSearchResults = [];
+
+        if (newValue !== 'use_existing') {
+          this.clearSelectedVenue();
+        }
 
         this.$nextTick(() => {
             $("#venue_country").countrySelect({


### PR DESCRIPTION
## Summary
- ensure the existing-venue dropdown is only required and enabled when it is visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69010695cb4c832eac713259a8ac9431