### PR TITLE
Fix venue dropdown validation when editing

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -1735,6 +1735,10 @@
         return !this.selectedVenue || this.showVenueAddressFields;
       },
       shouldShowExistingVenueDropdown() {
+        if (this.selectedVenue && !this.shouldBypassPreferences) {
+          return false;
+        }
+
         if (this.shouldBypassPreferences) {
           return true;
         }


### PR DESCRIPTION
## Summary
- prevent the venue dropdown from remaining required when an existing venue is already selected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69011042392c832eae2d8b589dc44d2e