### PR TITLE
Fix venue removal button on event edit form

### DIFF
--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -374,12 +374,12 @@
                                         <x-secondary-button v-if="!selectedVenue.user_id" x-on:click="editSelectedVenue" type="button" class="mr-2">
                                             {{ __('messages.edit') }}
                                         </x-secondary-button>
-                                        <x-secondary-button x-on:click="clearSelectedVenue" type="button">
+                                        <x-secondary-button @click="clearSelectedVenue()" type="button">
                                             {{ __('messages.remove') }}
                                         </x-secondary-button>
                                     </div>
                                 </div>
-                            </div>                        
+                            </div>
 
                         </div>
 


### PR DESCRIPTION
## Summary
- ensure the edit event venue removal button calls the Vue handler by using the correct click binding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690121f26298832e9a37a7b8e5289569