### PR TITLE
Ensure event share button links to info page

### DIFF
--- a/resources/views/event/show-guest.blade.php
+++ b/resources/views/event/show-guest.blade.php
@@ -35,7 +35,7 @@
             ? __('messages.view_event')
             : ($event->areTicketsFree() ? __('messages.get_tickets') : __('messages.buy_tickets'));
           $showTicketPurchaseCta = $ticketPurchaseUrl && request()->get('tickets') !== 'true';
-          $shareUrl = $ticketPurchaseUrl ?: request()->fullUrl();
+          $shareUrl = $event->getGuestUrl($role->subdomain, $date) ?: request()->fullUrlWithoutQuery('tickets');
           $shareTitle = $translation ? $translation->name_translated : $event->translatedName();
           $startAt = $event->getStartDateTime($date, true);
           $endAt = $startAt && $event->duration > 0 ? $startAt->copy()->addHours($event->duration) : null;


### PR DESCRIPTION
## Summary
- ensure the event share button always links to the event information page instead of the ticket purchase URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69015640033c832e9532ec8f42e9e870