### PR TITLE
Improve individual ticket view navigation

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -633,6 +633,7 @@ return [
     'event_support_contact' => 'Event Support Contact',
     'ticket' => 'Ticket',
     'view_tickets' => 'View Tickets',
+    'back_to_all_tickets' => 'Back to all tickets',
     'order_number' => 'Order Number',
     'notes' => 'Notes',
     'add_to_apple_wallet' => 'Add to Apple Wallet',

--- a/resources/views/ticket/view.blade.php
+++ b/resources/views/ticket/view.blade.php
@@ -187,6 +187,8 @@
         </div>
         @php
           $focusedEntryId = $focusedEntry->id ?? null;
+          $isViewingSingleTicket = $focusedEntryId !== null;
+          $totalEntries = $sale->saleTickets->sum(fn ($saleTicket) => $saleTicket->entries->count());
         @endphp
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-[18px] gap-y-[12px] mt-[20px]">
           <div>
@@ -212,9 +214,20 @@
                 {{ __('messages.add_tickets_to_wallet') }}
               </p>
             @endif
+            @if ($isViewingSingleTicket && $totalEntries > 1)
+              <a
+                href="{{ route('ticket.view', ['event_id' => \App\Utils\UrlUtils::encodeId($event->id), 'secret' => $sale->secret]) }}"
+                class="text-[10px] text-white/70 underline"
+              >
+                {{ __('messages.back_to_all_tickets') }}
+              </a>
+            @endif
             <div class="flex flex-col gap-[12px] w-full">
               @foreach ($sale->saleTickets as $saleTicket)
                 @foreach ($saleTicket->entries->sortBy('seat_number') as $entry)
+                  @if ($isViewingSingleTicket && $entry->id !== $focusedEntryId)
+                    @continue
+                  @endif
                   @php
                     $entryLabel = ($saleTicket->ticket->type ?: __('messages.ticket')) . ' #' . $entry->seat_number;
                     $isFocused = $focusedEntryId === $entry->id;


### PR DESCRIPTION
## Summary
- filter the ticket entry list so that entry-specific links focus on the selected ticket
- add navigation back to the aggregated ticket view when an individual ticket is open
- add a translation string for the new navigation link

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_69016fbad740832e8d439e579cdfa1a0