### PR TITLE
Include ticket expiry notice in unpaid reminders

### DIFF
--- a/app/Notifications/TicketPaymentReminderNotification.php
+++ b/app/Notifications/TicketPaymentReminderNotification.php
@@ -69,6 +69,18 @@ class TicketPaymentReminderNotification extends Notification
             $paymentInstructionsSection = __('messages.payment_instructions') . ":\n\n" . trim($event->payment_instructions) . "\n";
         }
 
+        $expireAfterHours = (int) ($event->expire_unpaid_tickets ?? 0);
+
+        $ticketExpiryNotice = '';
+
+        if ($expireAfterHours > 0) {
+            $ticketExpiryNotice = $expireAfterHours === 1
+                ? __('messages.payment_must_be_completed_within_hour')
+                : __('messages.payment_must_be_completed_within_hours', ['count' => $expireAfterHours]);
+
+            $ticketExpiryNotice .= "\n\n";
+        }
+
         $data = [
             'event_name' => $eventName,
             'event_date' => $eventDate,
@@ -82,6 +94,7 @@ class TicketPaymentReminderNotification extends Notification
             'app_name' => config('app.name'),
             'reminder_interval_hours' => (int) ($event->remind_unpaid_tickets_every ?? 0),
             'payment_instructions_section' => $paymentInstructionsSection,
+            'ticket_expiry_notice' => $ticketExpiryNotice,
         ];
 
         $subject = $templates->renderSubject($templateKey, $data);

--- a/config/mail_templates.php
+++ b/config/mail_templates.php
@@ -156,7 +156,7 @@ MD,
 - **Total Reserved:** :amount_total
 - **Order #:** :order_reference
 
-Complete your payment to keep your tickets. Reminders are sent every :reminder_interval_hours hour(s) until payment is received.
+:ticket_expiry_noticeComplete your payment to keep your tickets. Reminders are sent every :reminder_interval_hours hour(s) until payment is received.
 
 [Complete Payment](:ticket_view_url)
 
@@ -179,6 +179,7 @@ MD,
                 ':app_name' => 'The application name configured in settings.',
                 ':reminder_interval_hours' => 'Number of hours between payment reminder emails.',
                 ':payment_instructions_section' => 'Payment instructions defined on the event, including a translated heading when available.',
+                ':ticket_expiry_notice' => 'Optional notice describing when the reservation will expire.',
             ],
         ],
         'ticket_timeout_purchaser' => [

--- a/tests/Feature/SendUnpaidTicketRemindersCommandTest.php
+++ b/tests/Feature/SendUnpaidTicketRemindersCommandTest.php
@@ -151,6 +151,96 @@ class SendUnpaidTicketRemindersCommandTest extends TestCase
         Carbon::setTestNow(null);
     }
 
+    public function test_reminder_email_includes_expiry_notice_when_event_expires_unpaid_sales(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2024-06-10 10:00:00'));
+
+        $user = User::factory()->create();
+
+        $creatorRole = Role::withoutEvents(function () use ($user) {
+            return Role::create([
+                'user_id' => $user->id,
+                'subdomain' => 'expiry-reminder-creator',
+                'type' => 'talent',
+                'name' => 'Expiry Creator',
+                'email' => 'expiry-creator@example.com',
+                'timezone' => 'UTC',
+                'language_code' => 'en',
+            ]);
+        });
+
+        $venueRole = Role::withoutEvents(function () {
+            return Role::create([
+                'subdomain' => 'expiry-reminder-venue',
+                'type' => 'venue',
+                'name' => 'Expiry Venue',
+                'email' => 'expiry-venue@example.com',
+                'timezone' => 'UTC',
+                'language_code' => 'en',
+            ]);
+        });
+
+        $event = Event::withoutEvents(function () use ($user, $creatorRole, $venueRole) {
+            return Event::create([
+                'user_id' => $user->id,
+                'creator_role_id' => $creatorRole->id,
+                'role_id' => $creatorRole->id,
+                'venue_id' => $venueRole->id,
+                'name' => 'Expiry Reminder Event',
+                'slug' => 'expiry-reminder-event',
+                'starts_at' => Carbon::parse('2024-06-15 19:00:00'),
+                'tickets_enabled' => true,
+                'ticket_currency_code' => 'USD',
+                'payment_method' => 'cash',
+                'expire_unpaid_tickets' => 24,
+                'remind_unpaid_tickets_every' => 12,
+                'total_tickets_mode' => 'individual',
+            ]);
+        });
+
+        $ticket = Ticket::create([
+            'event_id' => $event->id,
+            'type' => 'General Admission',
+            'quantity' => 25,
+            'price' => 75,
+        ]);
+
+        $sale = Sale::create([
+            'event_id' => $event->id,
+            'name' => 'Expiry Reminder Buyer',
+            'email' => 'expiry-buyer@example.com',
+            'secret' => Str::random(32),
+            'event_date' => '2024-06-15',
+            'subdomain' => $creatorRole->subdomain,
+        ]);
+
+        $saleTicket = $sale->saleTickets()->create([
+            'ticket_id' => $ticket->id,
+            'quantity' => 3,
+        ]);
+
+        $saleTicket->entries()->createMany(collect(range(1, 3))->map(function ($seat) {
+            return [
+                'seat_number' => $seat,
+                'secret' => Str::lower(Str::random(32)),
+            ];
+        })->all());
+
+        $sale->payment_amount = 225;
+        $sale->created_at = Carbon::now()->subHours(12);
+        $sale->save();
+
+        $notification = new TicketPaymentReminderNotification($sale);
+
+        $mailMessage = $notification->toMail((object) []);
+
+        $body = $mailMessage->viewData['body'] ?? '';
+
+        $this->assertStringContainsString('Payment must be completed within 24 hours', $body);
+
+        Carbon::setTestNow(null);
+    }
+
     public function test_it_does_not_send_reminders_when_disabled(): void
     {
         Carbon::setTestNow(Carbon::parse('2024-04-10 09:00:00'));


### PR DESCRIPTION
## Summary
- show the ticket expiry window in unpaid reservation reminder emails using existing translations
- pass the expiry notice into the mail template data so it renders conditionally
- cover the new behaviour with a feature test that inspects the rendered reminder email

## Testing
- php artisan test --filter=SendUnpaidTicketRemindersCommandTest *(fails: composer install requires GitHub access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69056ff97b00832e8481143076e4d1f4