### PR TITLE
Add ticket sales export options

### DIFF
--- a/app/Utils/SimpleSpreadsheetExporter.php
+++ b/app/Utils/SimpleSpreadsheetExporter.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Utils;
+
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use ZipArchive;
+
+class SimpleSpreadsheetExporter
+{
+    /**
+     * @param array<int, array<int, string|int|float|null>> $rows
+     */
+    public static function downloadCsv(array $rows, string $filename): StreamedResponse
+    {
+        $response = new StreamedResponse(function () use ($rows) {
+            $handle = fopen('php://output', 'w');
+
+            if ($handle === false) {
+                return;
+            }
+
+            foreach ($rows as $row) {
+                fputcsv($handle, array_map(static function ($value) {
+                    if ($value === null) {
+                        return '';
+                    }
+
+                    return (string) $value;
+                }, $row));
+            }
+
+            fclose($handle);
+        });
+
+        $response->headers->set('Content-Type', 'text/csv');
+        $response->headers->set(
+            'Content-Disposition',
+            'attachment; filename="' . $filename . '"'
+        );
+
+        return $response;
+    }
+
+    /**
+     * @param array<int, array<int, string|int|float|null>> $rows
+     */
+    public static function downloadXlsx(array $rows, string $filename, ?string $sheetTitle = null): BinaryFileResponse
+    {
+        $path = tempnam(sys_get_temp_dir(), 'export');
+
+        if ($path === false) {
+            abort(500, 'Unable to create temporary file.');
+        }
+
+        $zip = new ZipArchive();
+
+        if ($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            @unlink($path);
+            abort(500, 'Unable to create spreadsheet archive.');
+        }
+
+        $title = $sheetTitle ? self::sanitizeSheetTitle($sheetTitle) : 'Sheet1';
+
+        $zip->addFromString('[Content_Types].xml', self::contentTypesXml());
+        $zip->addFromString('_rels/.rels', self::rootRelsXml());
+        $zip->addFromString('xl/_rels/workbook.xml.rels', self::workbookRelsXml());
+        $zip->addFromString('xl/workbook.xml', self::workbookXml($title));
+        $zip->addFromString('xl/worksheets/sheet1.xml', self::sheetXml($rows));
+
+        $zip->close();
+
+        $response = response()->download($path, $filename, [
+            'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        ]);
+
+        return $response->deleteFileAfterSend(true);
+    }
+
+    protected static function sanitizeSheetTitle(string $title): string
+    {
+        $title = Str::of($title)
+            ->replaceMatches('/[\[\]\*\?\\\/]/', '')
+            ->trim()
+            ->value();
+
+        if ($title === '') {
+            return 'Sheet1';
+        }
+
+        return mb_substr($title, 0, 31);
+    }
+
+    protected static function contentTypesXml(): string
+    {
+        return <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+    <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+XML;
+    }
+
+    protected static function rootRelsXml(): string
+    {
+        return <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+XML;
+    }
+
+    protected static function workbookRelsXml(): string
+    {
+        return <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+XML;
+    }
+
+    protected static function workbookXml(string $sheetTitle): string
+    {
+        $escapedTitle = htmlspecialchars($sheetTitle, ENT_XML1 | ENT_COMPAT, 'UTF-8');
+
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+    <sheets>
+        <sheet name="{$escapedTitle}" sheetId="1" r:id="rId1"/>
+    </sheets>
+</workbook>
+XML;
+    }
+
+    /**
+     * @param array<int, array<int, string|int|float|null>> $rows
+     */
+    protected static function sheetXml(array $rows): string
+    {
+        $xmlRows = [];
+
+        foreach ($rows as $rowIndex => $row) {
+            $cells = [];
+
+            foreach ($row as $columnIndex => $value) {
+                $columnLetter = self::columnLetter($columnIndex + 1);
+                $cellValue = htmlspecialchars((string) ($value ?? ''), ENT_XML1 | ENT_COMPAT, 'UTF-8');
+                $cells[] = '<c r="' . $columnLetter . ($rowIndex + 1) . '" t="inlineStr"><is><t>'
+                    . $cellValue
+                    . '</t></is></c>';
+            }
+
+            $xmlRows[] = '<row r="' . ($rowIndex + 1) . '">' . implode('', $cells) . '</row>';
+        }
+
+        $sheetData = implode('', $xmlRows);
+
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+    <sheetData>{$sheetData}</sheetData>
+</worksheet>
+XML;
+    }
+
+    protected static function columnLetter(int $columnNumber): string
+    {
+        $letter = '';
+
+        while ($columnNumber > 0) {
+            $columnNumber--;
+            $letter = chr(65 + ($columnNumber % 26)) . $letter;
+            $columnNumber = intdiv($columnNumber, 26);
+        }
+
+        return $letter;
+    }
+}

--- a/resources/views/event/view.blade.php
+++ b/resources/views/event/view.blade.php
@@ -263,6 +263,22 @@
                                             {{ __('messages.no_ticket_purchasers') }}
                                         </p>
                                     @else
+                                        <div class="mt-4 flex flex-wrap items-center justify-end gap-3">
+                                            <a href="{{ route('events.sales.export', ['hash' => \App\Utils\UrlUtils::encodeId($event->id), 'format' => 'csv']) }}"
+                                                class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800">
+                                                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 16.5v2.25A1.25 1.25 0 005.25 20h13.5A1.25 1.25 0 0020 18.75V16.5M16 12l-4 4m0 0l-4-4m4 4V3" />
+                                                </svg>
+                                                {{ __('messages.export_csv') }}
+                                            </a>
+                                            <a href="{{ route('events.sales.export', ['hash' => \App\Utils\UrlUtils::encodeId($event->id), 'format' => 'xlsx']) }}"
+                                                class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800">
+                                                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 16.5v2.25A1.25 1.25 0 005.25 20h13.5A1.25 1.25 0 0020 18.75V16.5M16 12l-4 4m0 0l-4-4m4 4V3" />
+                                                </svg>
+                                                {{ __('messages.export_excel') }}
+                                            </a>
+                                        </div>
                                         <div class="mt-4 overflow-x-auto">
                                             <table class="min-w-full divide-y divide-gray-200 text-sm">
                                                 <thead class="bg-gray-50 dark:bg-gray-900/60 text-gray-700 dark:text-gray-200">

--- a/resources/views/ticket/sales.blade.php
+++ b/resources/views/ticket/sales.blade.php
@@ -1,10 +1,13 @@
 <x-app-admin-layout>
+    @php
+        $exportQuery = request()->except('page');
+    @endphp
 
     <div class="mt-8 flow-root">
         <div class="flex flex-col sm:flex-row sm:justify-between gap-4">
             <div class="flex-1">
                 <div class="relative">
-                    <x-text-input type="text" name="filter" id="filter" placeholder="{{ __('messages.filter') }}" 
+                    <x-text-input type="text" name="filter" id="filter" placeholder="{{ __('messages.filter') }}"
                         value="{{ request()->filter }}" autocomplete="off"/>
                     <button type="button" id="clear-filter" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600" style="display: none;">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -14,16 +17,35 @@
                 </div>
             </div>
 
-            <a href="{{ route('ticket.scan') }}" class="w-full sm:w-auto">
-                <button type="button"
-                    class="w-full sm:w-auto inline-flex items-center justify-center rounded-md shadow-sm bg-[#4E81FA] px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#3A6BE0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA]">
-                    <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
-                        <path
-                            d="M4,4H10V10H4V4M20,4V10H14V4H20M14,15H16V13H14V11H16V13H18V11H20V13H18V15H20V18H18V20H16V18H13V20H11V16H14V15M16,15V18H18V15H16M4,20V14H10V20H4M6,6V8H8V6H6M16,6V8H18V6H16M6,16V18H8V16H6M4,11H6V13H4V11M9,11H13V15H11V13H9V11M11,6H13V10H11V6M2,2V6H0V2A2,2 0 0,1 2,0H6V2H2M22,0A2,2 0 0,1 24,2V6H22V2H18V0H22M2,18V22H6V24H2A2,2 0 0,1 0,22V18H2M22,22V18H24V22A2,2 0 0,1 22,24H18V22H22Z" />
-                    </svg>
-                    <span class="ml-1">{{ __('messages.scan_ticket') }}</span>
-                </button>
-            </a>
+            <div class="flex flex-col sm:flex-row sm:items-center gap-2 w-full sm:w-auto">
+                <div class="flex flex-wrap gap-2">
+                    <a href="{{ route('sales.export', array_merge($exportQuery, ['format' => 'csv'])) }}"
+                        class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800">
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 16.5v2.25A1.25 1.25 0 005.25 20h13.5A1.25 1.25 0 0020 18.75V16.5M16 12l-4 4m0 0l-4-4m4 4V3" />
+                        </svg>
+                        {{ __('messages.export_csv') }}
+                    </a>
+                    <a href="{{ route('sales.export', array_merge($exportQuery, ['format' => 'xlsx'])) }}"
+                        class="inline-flex items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA] dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800">
+                        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 16.5v2.25A1.25 1.25 0 005.25 20h13.5A1.25 1.25 0 0020 18.75V16.5M16 12l-4 4m0 0l-4-4m4 4V3" />
+                        </svg>
+                        {{ __('messages.export_excel') }}
+                    </a>
+                </div>
+
+                <a href="{{ route('ticket.scan') }}" class="w-full sm:w-auto">
+                    <button type="button"
+                        class="w-full sm:w-auto inline-flex items-center justify-center rounded-md shadow-sm bg-[#4E81FA] px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#3A6BE0] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#4E81FA]">
+                        <svg class="-ml-0.5 mr-1.5 h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                            <path
+                                d="M4,4H10V10H4V4M20,4V10H14V4H20M14,15H16V13H14V11H16V13H18V11H20V13H18V15H20V18H18V20H16V18H13V20H11V16H14V15M16,15V18H18V15H16M4,20V14H10V20H4M6,6V8H8V6H6M16,6V8H18V6H16M6,16V18H8V16H6M4,11H6V13H4V11M9,11H13V15H11V13H9V11M11,6H13V10H11V6M2,2V6H0V2A2,2 0 0,1 2,0H6V2H2M22,0A2,2 0 0,1 24,2V6H22V2H18V0H22M2,18V22H6V24H2A2,2 0 0,1 0,22V18H2M22,22V18H24V22A2,2 0 0,1 22,24H18V22H22Z" />
+                        </svg>
+                        <span class="ml-1">{{ __('messages.scan_ticket') }}</span>
+                    </button>
+                </a>
+            </div>
         </div>
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -99,6 +99,9 @@ Route::middleware(['auth', 'verified'])->group(function ()
     Route::post('/assets/images', [ImageController::class, 'store'])->name('images.store');
     Route::delete('/assets/images/{image}', [ImageController::class, 'destroy'])->name('images.destroy');
     Route::get('/events/{hash}/view', [EventController::class, 'view'])->name('events.view');
+    Route::get('/events/{hash}/sales/export/{format}', [TicketController::class, 'exportEventSales'])
+        ->whereIn('format', ['csv', 'xlsx'])
+        ->name('events.sales.export');
     Route::get('/events/{hash}/clone', [EventController::class, 'cloneConfirm'])->name('events.clone.confirm');
     Route::post('/events/{hash}/clone', [EventController::class, 'clone'])->name('events.clone');
     Route::delete('/events/{hash}', [EventController::class, 'destroyFromHome'])->name('events.destroy');
@@ -127,6 +130,9 @@ Route::middleware(['auth', 'verified'])->group(function ()
     Route::get('/pages', [RoleController::class, 'pages'])->name('role.pages');
     Route::get('/tickets', [TicketController::class, 'tickets'])->name('tickets');
     Route::get('/sales', [TicketController::class, 'sales'])->name('sales');
+    Route::get('/sales/export/{format}', [TicketController::class, 'exportSales'])
+        ->whereIn('format', ['csv', 'xlsx'])
+        ->name('sales.export');
     Route::post('/sales/action/{sale_id}', [TicketController::class, 'handleAction'])->name('sales.action');
     Route::post('/sales/{sale_id}/mark-used', [TicketController::class, 'markUsed'])->name('sales.mark_used');
     Route::post('/sales/actions', [TicketController::class, 'handleBulkAction'])->name('sales.actions');


### PR DESCRIPTION
## Summary
- add a reusable SimpleSpreadsheetExporter helper for CSV/XLSX downloads
- implement ticket sales export endpoints and buttons on the sales and event pages
- update the contacts export to use the shared exporter

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_69067571dd8c832e92fc74731ee7c8e1