### PR TITLE
Fix backslash escaping in sheet title sanitizer

### DIFF
--- a/app/Utils/SimpleSpreadsheetExporter.php
+++ b/app/Utils/SimpleSpreadsheetExporter.php
@@ -80,7 +80,7 @@ class SimpleSpreadsheetExporter
 
     protected static function sanitizeSheetTitle(string $title): string
     {
-        $title = str_replace(['[', ']', '*', '?', '\\', '/'], '', $title);
+        $title = str_replace(['[', ']', '*', '?', "\\", '/'], '', $title);
 
         $title = Str::of($title)
             ->trim()


### PR DESCRIPTION
## Summary
- correct the backslash escape sequence in the spreadsheet sheet title sanitizer to avoid syntax errors when parsing the file

## Testing
- php -l app/Utils/SimpleSpreadsheetExporter.php

------
https://chatgpt.com/codex/tasks/task_e_690698620bf8832e8baecd272ebb41cf