### PR TITLE
Restore separate routes for guest landing and authenticated events

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -10,6 +10,7 @@ use App\Utils\UrlUtils;
 use Illuminate\Support\Str;
 use Carbon\Carbon;
 use App\Mail\SupportEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Mail;
 
 class HomeController extends Controller
@@ -109,8 +110,16 @@ class HomeController extends Controller
 
         $venueOptions = $optionEvents
             ->map->venue
-            ->filter(function ($role) {
-                return $role && ! $role->is_deleted;
+            ->filter(function ($role) use ($user) {
+                if (! $role || $role->is_deleted) {
+                    return false;
+                }
+
+                if (! $user && $role->is_unlisted) {
+                    return false;
+                }
+
+                return true;
             })
             ->unique('id')
             ->sortBy(function ($role) {
@@ -119,12 +128,19 @@ class HomeController extends Controller
             ->values();
 
         $curatorOptions = $optionEvents
-            ->flatMap(function ($event) {
-                $curators = $event->roles->filter(function ($role) {
-                    return ! $role->is_deleted && $role->isCurator();
+            ->flatMap(function ($event) use ($user) {
+                $curators = $event->roles->filter(function ($role) use ($user) {
+                    if ($role->is_deleted || ($role->is_unlisted && ! $user)) {
+                        return false;
+                    }
+
+                    return $role->isCurator();
                 });
 
-                if ($event->creatorRole && ! $event->creatorRole->is_deleted && $event->creatorRole->isCurator()) {
+                if ($event->creatorRole
+                    && ! $event->creatorRole->is_deleted
+                    && ! (! $user && $event->creatorRole->is_unlisted)
+                    && $event->creatorRole->isCurator()) {
                     $curators->push($event->creatorRole);
                 }
 
@@ -137,9 +153,17 @@ class HomeController extends Controller
             ->values();
 
         $talentOptions = $optionEvents
-            ->flatMap(function ($event) {
-                return $event->roles->filter(function ($role) {
-                    return ! $role->is_deleted && $role->isTalent();
+            ->flatMap(function ($event) use ($user) {
+                return $event->roles->filter(function ($role) use ($user) {
+                    if ($role->is_deleted || ! $role->isTalent()) {
+                        return false;
+                    }
+
+                    if (! $user && $role->is_unlisted) {
+                        return false;
+                    }
+
+                    return true;
                 });
             })
             ->unique('id')
@@ -184,6 +208,23 @@ class HomeController extends Controller
             'calendarQueryParams' => $calendarQueryParams,
             'isAuthenticated' => (bool) $user,
         ]);
+    }
+
+    public function events(Request $request)
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return redirect()->route('public.home');
+        }
+
+        if ($user instanceof MustVerifyEmail && ! $user->hasVerifiedEmail()) {
+            return $request->expectsJson()
+                ? abort(403, 'Your email address is not verified.')
+                : redirect()->route('verification.notice');
+        }
+
+        return $this->home($request);
     }
 
     public function home(Request $request)

--- a/routes/web.php
+++ b/routes/web.php
@@ -321,5 +321,9 @@ if (config('app.env') == 'local') {
     Route::get('/blog/{slug}', [BlogController::class, 'show'])->name('blog.show');
 }
 
-Route::get('/events', [HomeController::class, 'landing'])->name('home');
+Route::get('/home', [HomeController::class, 'landing'])->name('public.home');
+Route::get('/events', [HomeController::class, 'events'])->name('home');
+Route::get('/', function () {
+    return redirect()->route('public.home');
+});
 Route::get('/{slug?}', [HomeController::class, 'landing'])->name('landing');


### PR DESCRIPTION
## Summary
- add a dedicated /home route for the public landing calendar and redirect the root URL there
- restore /events as the authenticated events dashboard while keeping unverified users on the verification notice

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908c4ec87c4832e886e39c4f194c5e5