### PR TITLE
Restore legacy events dashboard for authenticated users

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -14,6 +14,19 @@ use Mail;
 
 class HomeController extends Controller
 {
+    public function root(Request $request, $slug = null)
+    {
+        if ($slug) {
+            return $this->landing($request, $slug);
+        }
+
+        if ($request->user()) {
+            return $this->home($request);
+        }
+
+        return redirect()->route('landing', $request->query());
+    }
+
     public function landing(Request $request, $slug = null)
     {
         if ($slug && $role = Role::whereSubdomain($slug)->first()) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -321,5 +321,5 @@ if (config('app.env') == 'local') {
     Route::get('/blog/{slug}', [BlogController::class, 'show'])->name('blog.show');
 }
 
-Route::get('/events', [HomeController::class, 'landing'])->name('home');
-Route::get('/{slug?}', [HomeController::class, 'landing'])->name('landing');
+Route::get('/home', [HomeController::class, 'landing'])->name('landing');
+Route::get('/{slug?}', [HomeController::class, 'root'])->name('home');


### PR DESCRIPTION
## Summary
- add a root controller entry point that redirects guests to the public landing page while serving the legacy events view to authenticated users
- expose the new events landing page at `/home` and keep the root route named `home`

## Testing
- `php artisan test` *(fails: missing vendor directory in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69090a24d6a8832eb64f3a860b6407d0