### PR TITLE
Fix redirect loop for guest home route

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -24,7 +24,7 @@ class HomeController extends Controller
             return $this->home($request);
         }
 
-        return redirect()->route('landing', $request->query());
+        return $this->landing($request);
     }
 
     public function landing(Request $request, $slug = null)


### PR DESCRIPTION
## Summary
- stop redirecting guest traffic from the root route back to the landing route to avoid loops

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_69090dda6f30832eac1e29e2cb0c2088