### PR TITLE
Hide logo when desktop sidebar collapsed

### DIFF
--- a/resources/views/layouts/app-admin.blade.php
+++ b/resources/views/layouts/app-admin.blade.php
@@ -25,7 +25,7 @@
                 }
 
                 #desktop-sidebar[data-state="closed"] .sidebar-logo {
-                    justify-content: center;
+                    display: none;
                 }
 
                 #desktop-sidebar[data-state="closed"] .sidebar-item-label,


### PR DESCRIPTION
## Summary
- hide the sidebar logo when the desktop sidebar is collapsed so the icon area no longer displays

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a1fa866f4832e955d806b4a9b3025