### PR TITLE
Fix public calendar visibility and hide schedule creation button

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -74,7 +74,7 @@ class HomeController extends Controller
                 $query->where('event_role.is_accepted', true)
                     ->where('roles.is_deleted', false)
                     ->where('roles.is_unlisted', false)
-                    ->whereIn('roles.type', ['talent', 'schedule']);
+                    ->whereIn('roles.type', ['talent', 'schedule', 'venue']);
             });
         }
 

--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -134,7 +134,7 @@
                         {{ __('messages.save') }}
                     </button>
                 @endif
-            @elseif ($route == 'home')
+            @elseif ($route == 'home' && auth()->check())
                 <div style="font-family: sans-serif" class="relative inline-block text-left w-full md:w-auto">
                     <button type="button" onclick="onPopUpClick('calendar-pop-up-menu', event)" class="inline-flex w-full justify-center rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" id="menu-button" aria-expanded="true" aria-haspopup="true">
                         {{ __('messages.new_schedule') }}


### PR DESCRIPTION
## Summary
- prevent unauthenticated visitors from seeing the "New Schedule" control on the calendar
- widen the public landing event query to include events associated to public venues so upcoming shows render

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a2fc93630832e8d93cff61f8977f2