### PR TITLE
Add list view option to public landing page

### DIFF
--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -275,10 +275,11 @@
                             </div>
 
                             <div class="mt-6 space-y-5">
-                                @forelse($calendarEvents as $event)
+                                @forelse($calendarEvents as $occurrence)
                                     @php
+                                        $event = $occurrence['event'];
                                         $eventUrl = $event->getGuestUrl(false, true);
-                                        $startsAt = $event->localStartsAt(true);
+                                        $startsAt = $occurrence['occurs_at_display'] ?? $event->localStartsAt(true);
                                         $venueName = $event->getVenueDisplayName();
                                         $talentList = $event->roles->filter(function ($role) {
                                             return $role->isTalent();


### PR DESCRIPTION
## Summary
- allow the landing page to toggle between calendar and list views for unauthenticated users
- build a styled event list with month navigation, event metadata, and preserved filter/query parameters
- keep existing calendar experience intact while carrying view state through filters and reset links

## Testing
- not run (vendor/bin/phpunit not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_690a409363d4832ea186f9eb8f7554b8