### PR TITLE
Restyle unauthenticated calendar view toggle

### DIFF
--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -190,23 +190,38 @@
 
                 <div class="bg-white dark:bg-gray-900 shadow-sm rounded-2xl border border-gray-100 dark:border-gray-800 p-4 sm:p-6">
                     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between border-b border-gray-100 pb-4 dark:border-gray-800">
-                        <div class="inline-flex items-center rounded-full bg-slate-100 p-1 text-sm font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-                            <a href="{{ route($calendarRouteName, $calendarViewParams) }}"
-                               class="@class([
-                                   'inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600',
-                                   'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white' => ! $isListView,
-                                   'text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white' => $isListView,
-                               ])">
-                                {{ __('messages.calendar') }}
-                            </a>
-                            <a href="{{ route($calendarRouteName, $listViewParams) }}"
-                               class="@class([
-                                   'inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600',
-                                   'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white' => $isListView,
-                                   'text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white' => ! $isListView,
-                               ])">
-                                {{ __('messages.list') }}
-                            </a>
+                        <div class="flex items-center gap-2">
+                            <span class="text-sm font-medium text-gray-600 dark:text-gray-300">{{ __('messages.layout') }}</span>
+                            <div class="inline-flex rounded-full border border-gray-200 bg-gray-100 p-0.5 text-sm font-medium dark:border-gray-700 dark:bg-gray-800">
+                                <a href="{{ route($calendarRouteName, $listViewParams) }}"
+                                   class="@class([
+                                       'inline-flex items-center gap-1 rounded-full px-3 py-1.5 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600',
+                                       'bg-white text-gray-900 shadow-sm ring-1 ring-inset ring-gray-200 dark:bg-gray-900 dark:text-gray-100 dark:ring-gray-700' => $isListView,
+                                       'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' => ! $isListView,
+                                   ])"
+                                   @if($isListView) aria-current="page" @endif
+                                >
+                                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M7 6h13M4 6h.01M7 12h13M4 12h.01M7 18h13M4 18h.01" />
+                                    </svg>
+                                    {{ __('messages.list') }}
+                                </a>
+                                <a href="{{ route($calendarRouteName, $calendarViewParams) }}"
+                                   class="@class([
+                                       'inline-flex items-center gap-1 rounded-full px-3 py-1.5 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600',
+                                       'bg-white text-gray-900 shadow-sm ring-1 ring-inset ring-gray-200 dark:bg-gray-900 dark:text-gray-100 dark:ring-gray-700' => ! $isListView,
+                                       'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' => $isListView,
+                                   ])"
+                                   @unless($isListView) aria-current="page" @endunless
+                                >
+                                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 8.25C3 7.007 3.993 6 5.25 6h13.5C19.507 6 20.5 7.007 20.5 8.25v9.5A1.25 1.25 0 0119.25 19H4.75A1.75 1.75 0 013 17.25v-9z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M8 6V4.75A1.75 1.75 0 019.75 3h4.5A1.75 1.75 0 0116 4.75V6" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 10.5h17.5" />
+                                    </svg>
+                                    {{ __('messages.calendar') }}
+                                </a>
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- restyle the public calendar/list toggle to match the venue layout switcher
- add icons, layout label, and active state ring styling for the list/calendar options

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a5d956bdc832e8de1d70f8346b550