### PR TITLE
Fix system role pivot column

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -151,7 +151,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
     public function systemRoles(): BelongsToMany
     {
-        return $this->belongsToMany(SystemRole::class, 'user_roles')
+        return $this->belongsToMany(SystemRole::class, 'user_roles', 'user_id', 'role_id')
             ->withTimestamps();
     }
 


### PR DESCRIPTION
## Summary
- ensure the `systemRoles` relationship on `User` uses the correct pivot columns

## Testing
- `php artisan test` *(fails: vendor directory not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5f220148832e8fb8edba3a554803)