### PR TITLE
Register custom middleware alias

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,8 @@ use App\Http\Middleware\SetUserLanguage;
 use App\Http\Middleware\EnsureEmailIsVerified;
 use App\Http\Middleware\HandleBotTraffic;
 use App\Http\Middleware\SecurityHeaders;
+use App\Http\Middleware\ApiAuthentication;
+use App\Http\Middleware\EnsureAbility;
 use Sentry\Laravel\Integration;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -21,6 +23,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
+        $middleware->alias([
+            'api.auth' => ApiAuthentication::class,
+            'ability' => EnsureAbility::class,
+        ]);
+
         $middleware->validateCsrfTokens(except: [
             'stripe/webhook',
             'invoiceninja/webhook/*',


### PR DESCRIPTION
## Summary
- register the custom `ability` and `api.auth` middleware aliases during bootstrap so they are available to routes
- import the middleware classes referenced by the new aliases

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b6d791184832eb14773a9d838e13b)