### PR TITLE
Allow legacy admin fallback for ability checks

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -335,6 +335,11 @@ class User extends Authenticatable implements MustVerifyEmail
             return true;
         }
 
+        return $this->hasLegacyAdminAccess();
+    }
+
+    public function hasLegacyAdminAccess(): bool
+    {
         if (! $this->shouldUseLegacyAdminFallback()) {
             return false;
         }

--- a/app/Services/Authorization/AuthorizationService.php
+++ b/app/Services/Authorization/AuthorizationService.php
@@ -36,6 +36,10 @@ class AuthorizationService
 
     public function userHasPermission(User $user, string $permissionKey): bool
     {
+        if ($this->legacyAdminAccessApplies($user)) {
+            return true;
+        }
+
         if (! $this->permissionsAvailable()) {
             return false;
         }
@@ -92,6 +96,11 @@ class AuthorizationService
                 ->values()
                 ->all();
         });
+    }
+
+    protected function legacyAdminAccessApplies(User $user): bool
+    {
+        return method_exists($user, 'hasLegacyAdminAccess') && $user->hasLegacyAdminAccess();
     }
 
     protected function userCacheKey(int $userId): string


### PR DESCRIPTION
## Summary
- expose the legacy admin fallback logic via `User::hasLegacyAdminAccess` so it can be reused outside of `isAdmin`
- let the authorization service grant permissions through the legacy admin fallback when no system roles exist yet, restoring first-user access to settings

## Testing
- `php artisan test --filter=SettingsTest` *(fails: missing `vendor/autoload.php` because Composer dependencies are not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b70970df8832ea0b49c17f658bf31)