### PR TITLE
Ensure default system roles are seeded

### DIFF
--- a/database/migrations/2026_10_10_000000_seed_default_system_roles.php
+++ b/database/migrations/2026_10_10_000000_seed_default_system_roles.php
@@ -1,0 +1,35 @@
+<?php
+
+use Database\Seeders\AuthorizationSeeder;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! $this->authorizationTablesExist()) {
+            return;
+        }
+
+        if (DB::table('auth_roles')->exists()) {
+            return;
+        }
+
+        app(AuthorizationSeeder::class)->run();
+    }
+
+    public function down(): void
+    {
+        // No-op: we only seed data when the tables are empty.
+    }
+
+    private function authorizationTablesExist(): bool
+    {
+        return Schema::hasTable('auth_roles')
+            && Schema::hasTable('permissions')
+            && Schema::hasTable('role_permissions')
+            && Schema::hasTable('user_roles');
+    }
+};

--- a/tests/Feature/AuthorizationMigrationTest.php
+++ b/tests/Feature/AuthorizationMigrationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SystemRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthorizationMigrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_default_system_roles_are_seeded_during_migrations(): void
+    {
+        $this->assertGreaterThanOrEqual(1, SystemRole::count());
+    }
+}


### PR DESCRIPTION
## Summary
- add a migration that runs the `AuthorizationSeeder` whenever the authorization tables exist but no system roles have been created yet, ensuring the user management UI always has roles to display
- cover the behavior with a regression test that asserts migrations seed at least one system role

## Testing
- `php artisan test --filter AuthorizationMigrationTest` *(fails in this environment before vendor dependencies can be installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b869b3dd8832e9ae4fdae276caf76)