### PR TITLE
Improve user management breadcrumbs and password form

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -176,6 +176,8 @@ return [
     'assign_roles_help' => 'Select the global roles this user should inherit. Changes take effect immediately.',
     'cannot_assign_roles_warning' => 'You do not have permission to assign roles.',
     'password_optional_for_existing_user' => 'Leave blank to keep the current password.',
+    'set_password' => 'Set password',
+    'keep_existing_password' => 'Keep existing password',
     'user_created' => 'User account created successfully.',
     'user_updated' => 'User account updated successfully.',
     'roles' => 'Roles',

--- a/resources/views/settings/users/create.blade.php
+++ b/resources/views/settings/users/create.blade.php
@@ -3,6 +3,14 @@
         <div class="mx-auto max-w-4xl space-y-6">
             <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-100 dark:bg-gray-900 dark:ring-gray-800">
                 <div class="mb-6 border-b border-gray-100 pb-4 dark:border-gray-800">
+                    <x-breadcrumbs
+                        :items="[
+                            ['label' => __('messages.settings'), 'url' => route('settings.index')],
+                            ['label' => __('messages.user_management'), 'url' => route('settings.users.index')],
+                            ['label' => __('messages.add_user'), 'current' => true],
+                        ]"
+                        class="text-xs text-gray-500 dark:text-gray-400"
+                    />
                     <p class="text-sm font-medium text-indigo-600">{{ __('messages.user_management') }}</p>
                     <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">{{ __('messages.create_user') }}</h1>
                     <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('messages.create_user_description') }}</p>

--- a/resources/views/settings/users/edit.blade.php
+++ b/resources/views/settings/users/edit.blade.php
@@ -3,6 +3,14 @@
         <div class="mx-auto max-w-4xl space-y-6">
             <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-100 dark:bg-gray-900 dark:ring-gray-800">
                 <div class="mb-6 border-b border-gray-100 pb-4 dark:border-gray-800">
+                    <x-breadcrumbs
+                        :items="[
+                            ['label' => __('messages.settings'), 'url' => route('settings.index')],
+                            ['label' => __('messages.user_management'), 'url' => route('settings.users.index')],
+                            ['label' => __('messages.edit_user'), 'current' => true],
+                        ]"
+                        class="text-xs text-gray-500 dark:text-gray-400"
+                    />
                     <p class="text-sm font-medium text-indigo-600">{{ __('messages.user_management') }}</p>
                     <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">{{ __('messages.edit_user') }}</h1>
                     <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">

--- a/resources/views/settings/users/index.blade.php
+++ b/resources/views/settings/users/index.blade.php
@@ -3,7 +3,14 @@
         <div class="mx-auto max-w-6xl space-y-6">
             <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-100 dark:bg-gray-900 dark:ring-gray-800">
                 <div class="flex flex-col gap-4 border-b border-gray-100 pb-4 md:flex-row md:items-center md:justify-between dark:border-gray-800">
-                    <div>
+                    <div class="space-y-2">
+                        <x-breadcrumbs
+                            :items="[
+                                ['label' => __('messages.settings'), 'url' => route('settings.index')],
+                                ['label' => __('messages.user_management'), 'current' => true],
+                            ]"
+                            class="text-xs text-gray-500 dark:text-gray-400"
+                        />
                         <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">{{ __('messages.user_management') }}</h1>
                         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('messages.user_management_description') }}</p>

--- a/resources/views/settings/users/partials/form.blade.php
+++ b/resources/views/settings/users/partials/form.blade.php
@@ -1,5 +1,6 @@
 @php
     $assignedRoles = collect(old('roles', isset($managedUser) ? $managedUser->systemRoles->pluck('id')->all() : []))->map(fn ($id) => (int) $id)->all();
+    $showPasswordFields = $passwordRequired || ! is_null(old('password')) || ! is_null(old('password_confirmation'));
 @endphp
 
 <div class="space-y-6">
@@ -30,31 +31,72 @@
         <x-input-error class="mt-2" :messages="$errors->get('email')" />
     </div>
 
-    <div class="grid gap-6 md:grid-cols-2">
-        <div>
-            <x-input-label for="password" :value="$passwordLabel" />
-            <x-text-input
-                id="password"
-                name="password"
-                type="password"
-                class="mt-1 block w-full"
-                {{ $passwordRequired ? 'required' : '' }}
-            />
+    <div
+        x-data="{ showPasswordFields: {{ $showPasswordFields ? 'true' : 'false' }} }"
+        class="space-y-4"
+    >
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <x-input-label for="password" :value="$passwordLabel" />
+                @if (! $passwordRequired)
+                    <p class="mt-1 text-sm text-gray-500" x-show="!showPasswordFields">
+                        {{ __('messages.password_optional_for_existing_user') }}
+                    </p>
+                @endif
+            </div>
+
             @if (! $passwordRequired)
-                <p class="mt-2 text-sm text-gray-500">{{ __('messages.password_optional_for_existing_user') }}</p>
+                <div class="flex gap-3 text-sm font-medium">
+                    <button
+                        type="button"
+                        class="text-indigo-600 transition hover:text-indigo-500"
+                        x-show="!showPasswordFields"
+                        @click="showPasswordFields = true"
+                    >
+                        {{ __('messages.set_password') }}
+                    </button>
+                    <button
+                        type="button"
+                        class="text-gray-500 transition hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                        x-show="showPasswordFields"
+                        @click="
+                            showPasswordFields = false;
+                            if ($refs.password) $refs.password.value = '';
+                            if ($refs.passwordConfirmation) $refs.passwordConfirmation.value = '';
+                        "
+                    >
+                        {{ __('messages.keep_existing_password') }}
+                    </button>
+                </div>
             @endif
-            <x-input-error class="mt-2" :messages="$errors->get('password')" />
         </div>
-        <div>
-            <x-input-label for="password_confirmation" :value="__('messages.confirm_password')" />
-            <x-text-input
-                id="password_confirmation"
-                name="password_confirmation"
-                type="password"
-                class="mt-1 block w-full"
-                {{ $passwordRequired ? 'required' : '' }}
-            />
-            <x-input-error class="mt-2" :messages="$errors->get('password_confirmation')" />
+
+        <div class="grid gap-6 md:grid-cols-2" x-show="showPasswordFields">
+            <div>
+                <x-text-input
+                    id="password"
+                    x-ref="password"
+                    name="password"
+                    type="password"
+                    class="mt-1 block w-full"
+                    autocomplete="new-password"
+                    {{ $passwordRequired ? 'required' : '' }}
+                />
+                <x-input-error class="mt-2" :messages="$errors->get('password')" />
+            </div>
+            <div>
+                <x-input-label for="password_confirmation" :value="__('messages.confirm_password')" />
+                <x-text-input
+                    id="password_confirmation"
+                    x-ref="passwordConfirmation"
+                    name="password_confirmation"
+                    type="password"
+                    class="mt-1 block w-full"
+                    autocomplete="new-password"
+                    {{ $passwordRequired ? 'required' : '' }}
+                />
+                <x-input-error class="mt-2" :messages="$errors->get('password_confirmation')" />
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add contextual breadcrumbs to the user management index as well as the create and edit screens so navigation is consistent
- add a password toggle flow so admins can opt in to setting a password, plus translations for the new copy

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing and composer install could not reach GitHub due to 403 errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8ac59e28832e8fce332a9336f485)