### PR TITLE
Align general settings UI and fix password inputs

### DIFF
--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -11,55 +11,63 @@
         }
 
     @endphp
-    <div class="py-12">
-        <div class="max-w-4xl mx-auto space-y-6">
-            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow-md sm:rounded-lg">
-                <div class="max-w-3xl">
-                    <div class="mb-6">
-                        <a href="{{ route('settings.index') }}" class="inline-flex items-center gap-2 text-sm font-medium text-[#4E81FA] hover:text-[#365fcc]">
-                            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-                            </svg>
-                            {{ __('messages.back_to_settings') }}
-                        </a>
+
+    <div class="py-10">
+        <div class="mx-auto max-w-6xl space-y-6">
+            <div class="rounded-xl bg-white p-6 shadow-sm ring-1 ring-gray-100 dark:bg-gray-900 dark:ring-gray-800">
+                <div class="mb-6 border-b border-gray-100 pb-4 dark:border-gray-800">
+                    <x-breadcrumbs
+                        :items="[
+                            ['label' => __('messages.settings'), 'url' => route('settings.index')],
+                            ['label' => __('messages.general_settings'), 'current' => true],
+                        ]"
+                        class="text-xs text-gray-500 dark:text-gray-400"
+                    />
+                    <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
+                    <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
+                        {{ __('messages.general_settings') }}
+                    </h1>
+                    <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                        {{ __('messages.general_settings_description') }}
+                    </p>
+                </div>
+
+                <form method="post" action="{{ route('settings.general.update') }}" class="space-y-6">
+                    @csrf
+                    @method('patch')
+
+                    <div>
+                        <x-input-label for="public_url" :value="__('messages.public_url')" />
+                        <x-text-input
+                            id="public_url"
+                            name="public_url"
+                            type="url"
+                            class="mt-1 block w-full"
+                            :value="old('public_url', data_get($generalSettings, 'public_url'))"
+                            autocomplete="off"
+                        />
+                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                            {{ __('messages.public_url_help') }}
+                        </p>
+                        <x-input-error class="mt-2" :messages="$errors->get('public_url')" />
                     </div>
 
-                    <section>
-                        <header>
-                            <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-                                {{ __('messages.general_settings') }}
-                            </h2>
+                    <div class="flex items-center gap-4">
+                        <x-primary-button>{{ __('messages.save') }}</x-primary-button>
 
-                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                {{ __('messages.general_settings_description') }}
+                        @if (session('status') === 'general-settings-updated')
+                            <p
+                                x-data="{ show: true }"
+                                x-show="show"
+                                x-transition
+                                x-init="setTimeout(() => show = false, 2000)"
+                                class="text-sm text-gray-600 dark:text-gray-400"
+                            >
+                                {{ __('messages.general_settings_saved') }}
                             </p>
-                        </header>
-
-                        <form method="post" action="{{ route('settings.general.update') }}" class="mt-6 space-y-6">
-                            @csrf
-                            @method('patch')
-
-                            <div>
-                                <x-input-label for="public_url" :value="__('messages.public_url')" />
-                                <x-text-input id="public_url" name="public_url" type="url" class="mt-1 block w-full"
-                                    :value="old('public_url', data_get($generalSettings, 'public_url'))" autocomplete="off" />
-                                <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                    {{ __('messages.public_url_help') }}
-                                </p>
-                                <x-input-error class="mt-2" :messages="$errors->get('public_url')" />
-                            </div>
-
-                            <div class="flex items-center gap-4">
-                                <x-primary-button>{{ __('messages.save') }}</x-primary-button>
-
-                                @if (session('status') === 'general-settings-updated')
-                                    <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
-                                        class="text-sm text-gray-600 dark:text-gray-400">{{ __('messages.general_settings_saved') }}</p>
-                                @endif
-                            </div>
-                        </form>
-                    </section>
-                </div>
+                        @endif
+                    </div>
+                </form>
             </div>
         </div>
     </div>

--- a/resources/views/settings/users/partials/form.blade.php
+++ b/resources/views/settings/users/partials/form.blade.php
@@ -37,7 +37,7 @@
     >
         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
-                <x-input-label for="password" :value="$passwordLabel" />
+                <p class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ $passwordLabel }}</p>
                 @if (! $passwordRequired)
                     <p class="mt-1 text-sm text-gray-500" x-show="!showPasswordFields">
                         {{ __('messages.password_optional_for_existing_user') }}
@@ -73,6 +73,7 @@
 
         <div class="grid gap-6 md:grid-cols-2" x-show="showPasswordFields">
             <div>
+                <x-input-label for="password" :value="__('messages.password')" />
                 <x-text-input
                     id="password"
                     x-ref="password"


### PR DESCRIPTION
## Summary
- restyle the general settings page to match the rest of the settings UI, including breadcrumbs and consistent spacing
- add an explicit password label next to the actual password input while keeping the helper text for optional password updates

## Testing
- `php artisan test` *(fails: missing `vendor/autoload.php` in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9ed499e4832e837518bf020a5bcf)