### PR TITLE
Improve password section accessibility

### DIFF
--- a/resources/views/settings/users/partials/form.blade.php
+++ b/resources/views/settings/users/partials/form.blade.php
@@ -31,15 +31,15 @@
         <x-input-error class="mt-2" :messages="$errors->get('email')" />
     </div>
 
-    <div class="space-y-4">
-        <div>
-            <x-input-label for="password" :value="$passwordLabel" />
-            @if (! $passwordRequired)
-                <p class="mt-1 text-sm text-gray-500">
-                    {{ __('messages.password_optional_for_existing_user') }}
-                </p>
-            @endif
-        </div>
+    <fieldset class="space-y-4">
+        <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {{ $passwordLabel }}
+        </legend>
+        @if (! $passwordRequired)
+            <p class="mt-1 text-sm text-gray-500">
+                {{ __('messages.password_optional_for_existing_user') }}
+            </p>
+        @endif
 
         <div class="grid gap-6 md:grid-cols-2">
             <div>
@@ -67,7 +67,7 @@
                 <x-input-error class="mt-2" :messages="$errors->get('password_confirmation')" />
             </div>
         </div>
-    </div>
+    </fieldset>
 
     <div>
         <x-input-label for="timezone" :value="__('messages.timezone')" />


### PR DESCRIPTION
## Summary
- replace the redundant password section label with a semantic fieldset/legend so the heading no longer interferes with the actual password inputs
- keep the existing password and confirmation inputs unchanged while preserving the helper text styling

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bcd860798832e996a9d105e96ba31)