### PR TITLE
Fix optional password validation

### DIFF
--- a/app/Http/Controllers/UserManagementController.php
+++ b/app/Http/Controllers/UserManagementController.php
@@ -105,7 +105,13 @@ class UserManagementController extends Controller
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', Rule::unique(User::class, 'email')->ignore($user->getKey())],
-            'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+            'password' => [
+                'nullable',
+                Rule::when(
+                    fn ($input) => filled($input->password),
+                    ['string', 'min:8', 'confirmed']
+                ),
+            ],
             'timezone' => ['required', 'timezone'],
             'language_code' => ['required', 'string', Rule::in(array_keys($this->languageOptions()))],
             'roles' => $canManageRoles ? ['array'] : ['prohibited'],

--- a/tests/Feature/UserManagementTest.php
+++ b/tests/Feature/UserManagementTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_update_user_without_password_changes(): void
+    {
+        $admin = User::factory()->create();
+        $managedUser = User::factory()->create([
+            'password' => Hash::make('initial-pass'),
+        ]);
+
+        $response = $this
+            ->actingAs($admin)
+            ->patch(route('settings.users.update', $managedUser), [
+                'name' => 'Updated Name',
+                'email' => 'updated@example.com',
+                'password' => '',
+                'password_confirmation' => '',
+                'timezone' => 'UTC',
+                'language_code' => 'en',
+            ]);
+
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect(route('settings.users.index'));
+
+        $managedUser->refresh();
+
+        $this->assertSame('Updated Name', $managedUser->name);
+        $this->assertSame('updated@example.com', $managedUser->email);
+        $this->assertTrue(Hash::check('initial-pass', $managedUser->password));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the optional password fields on the user management edit form only validate when a new value is provided
- add a feature test that covers updating a user without changing the password

## Testing
- Not run (composer install failed: GitHub zipball downloads were blocked, so the test suite could not be executed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd6cbb1d8832e8999737f7626a4df)