### PR TITLE
Improve settings page headers

### DIFF
--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -15,7 +15,7 @@
 @endphp
 
 @if ($items->isNotEmpty())
-    <nav aria-label="{{ $ariaLabel }}" {{ $attributes->merge(['class' => 'flex text-sm text-gray-500 dark:text-gray-400']) }}>
+    <nav aria-label="{{ $ariaLabel }}" {{ $attributes->merge(['class' => 'flex text-base text-gray-500 dark:text-gray-400']) }}>
         <ol role="list" class="flex flex-wrap items-center gap-x-2 gap-y-1">
             @foreach ($items as $index => $item)
                 <li class="flex items-center gap-2">

--- a/resources/views/settings/branding.blade.php
+++ b/resources/views/settings/branding.blade.php
@@ -110,7 +110,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.branding_settings_heading') }}
                         </h1>

--- a/resources/views/settings/email-templates.blade.php
+++ b/resources/views/settings/email-templates.blade.php
@@ -11,7 +11,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.email_templates') }}
                         </h1>

--- a/resources/views/settings/email-templates/show.blade.php
+++ b/resources/views/settings/email-templates/show.blade.php
@@ -12,7 +12,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.email_templates') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ $template['label'] }}
                         </h1>

--- a/resources/views/settings/email.blade.php
+++ b/resources/views/settings/email.blade.php
@@ -28,7 +28,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.email_settings') }}
                         </h1>

--- a/resources/views/settings/event-types.blade.php
+++ b/resources/views/settings/event-types.blade.php
@@ -11,7 +11,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.event_type_settings') }}
                         </h1>

--- a/resources/views/settings/general.blade.php
+++ b/resources/views/settings/general.blade.php
@@ -23,7 +23,6 @@
                         ]"
                         class="text-xs text-gray-500 dark:text-gray-400"
                     />
-                    <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                     <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                         {{ __('messages.general_settings') }}
                     </h1>

--- a/resources/views/settings/home.blade.php
+++ b/resources/views/settings/home.blade.php
@@ -31,7 +31,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.home_settings_heading') }}
                         </h1>

--- a/resources/views/settings/integrations.blade.php
+++ b/resources/views/settings/integrations.blade.php
@@ -11,7 +11,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.integrations_settings') }}
                         </h1>

--- a/resources/views/settings/logging.blade.php
+++ b/resources/views/settings/logging.blade.php
@@ -55,7 +55,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.logging_settings') }}
                         </h1>

--- a/resources/views/settings/terms.blade.php
+++ b/resources/views/settings/terms.blade.php
@@ -11,7 +11,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.terms_settings') }}
                         </h1>

--- a/resources/views/settings/updates.blade.php
+++ b/resources/views/settings/updates.blade.php
@@ -59,7 +59,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.update_settings') }}
                         </h1>

--- a/resources/views/settings/users/create.blade.php
+++ b/resources/views/settings/users/create.blade.php
@@ -11,7 +11,6 @@
                         ]"
                         class="text-xs text-gray-500 dark:text-gray-400"
                     />
-                    <p class="text-sm font-medium text-indigo-600">{{ __('messages.user_management') }}</p>
                     <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">{{ __('messages.create_user') }}</h1>
                     <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('messages.create_user_description') }}</p>
                 </div>

--- a/resources/views/settings/users/edit.blade.php
+++ b/resources/views/settings/users/edit.blade.php
@@ -11,7 +11,6 @@
                         ]"
                         class="text-xs text-gray-500 dark:text-gray-400"
                     />
-                    <p class="text-sm font-medium text-indigo-600">{{ __('messages.user_management') }}</p>
                     <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">{{ __('messages.edit_user') }}</h1>
                     <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
                         {{ __('messages.edit_user_description', ['name' => $managedUser->name]) }}

--- a/resources/views/settings/users/index.blade.php
+++ b/resources/views/settings/users/index.blade.php
@@ -11,7 +11,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">{{ __('messages.user_management') }}</h1>
                         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ __('messages.user_management_description') }}</p>
                     </div>

--- a/resources/views/settings/wallet.blade.php
+++ b/resources/views/settings/wallet.blade.php
@@ -11,7 +11,6 @@
                             ]"
                             class="text-xs text-gray-500 dark:text-gray-400"
                         />
-                        <p class="text-sm font-medium text-indigo-600">{{ __('messages.settings') }}</p>
                         <h1 class="mt-2 text-2xl font-semibold text-gray-900 dark:text-white">
                             {{ __('messages.wallet_settings') }}
                         </h1>


### PR DESCRIPTION
## Summary
- remove the redundant "Settings" label that appeared under the breadcrumbs on each settings page
- increase the breadcrumb font size for better readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6c12ad24832e9c0f5d728f1bc7fe)