### PR TITLE
Move access level indicator to account dropdown

### DIFF
--- a/resources/views/layouts/app-admin.blade.php
+++ b/resources/views/layouts/app-admin.blade.php
@@ -311,6 +311,7 @@
                                         $userName = trim((string) data_get($authenticatedUser, 'name', ''));
                                         $userEmail = trim((string) data_get($authenticatedUser, 'email', ''));
                                         $displayName = $userName !== '' ? $userName : $userEmail;
+                                        $accessRoles = $authenticatedUser?->systemRoles?->sortBy('name') ?? collect();
                                     @endphp
                                     <button
                                         class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150 dark:bg-gray-800 dark:text-gray-200 dark:hover:text-gray-100">
@@ -331,6 +332,19 @@
                                     <x-dropdown-link :href="route('profile.edit')">
                                         {{ __('messages.manage_account') }}
                                     </x-dropdown-link>
+
+                                    @if ($accessRoles->isNotEmpty())
+                                        <div class="border-t border-gray-100 px-4 pt-3 pb-2 text-xs text-gray-500 dark:border-gray-600 dark:text-gray-300">
+                                            <p class="text-[0.6rem] uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('messages.access_level') }}</p>
+                                            <div class="mt-2 flex flex-wrap gap-2">
+                                                @foreach ($accessRoles as $systemRole)
+                                                    <span class="rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[0.7rem] font-semibold text-indigo-800 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200">
+                                                        {{ $systemRole->name }}
+                                                    </span>
+                                                @endforeach
+                                            </div>
+                                        </div>
+                                    @endif
 
                                     <!-- Authentication -->
                                     <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -50,9 +50,6 @@
 @php
     $navigationLogo = config('branding.logo_path');
     $logoAlt = branding_logo_alt();
-    $accessRoles = auth()->check()
-        ? auth()->user()->systemRoles->sortBy('name')
-        : collect();
 @endphp
 
 <a href="{{ app_public_url() }}" class="block">
@@ -66,18 +63,6 @@
     </div>
 </a>
 <nav class="flex flex-1 flex-col">
-    @if ($accessRoles->isNotEmpty())
-        <div class="mb-4 rounded-xl border border-gray-200 bg-white/80 p-3 text-xs font-medium text-gray-700 shadow-sm dark:bor-der-gray-700 dark:bg-gray-900/60 dark:text-gray-200">
-            <p class="text-[0.6rem] uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ __('messages.access_level') }}</p>
-            <div class="mt-2 flex flex-wrap gap-2">
-                @foreach ($accessRoles as $systemRole)
-                    <span class="rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-[0.7rem] font-semibold text-indigo-800 dark:border-indigo-500/40 dark:bg-indigo-500/10 dark:text-indigo-200">
-                        {{ $systemRole->name }}
-                    </span>
-                @endforeach
-            </div>
-        </div>
-    @endif
     <ul role="list" class="flex flex-1 flex-col gap-y-7">
         <li>
             <ul role="list" class="-mx-2 space-y-1">


### PR DESCRIPTION
## Summary
- remove the access level badges from the sidebar navigation
- surface the user access roles beneath the "Manage Account" link in the account dropdown so the information is available alongside account controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c711545d8832e8a8ea9d90e3b3219)