### PR TITLE
Allow role members to view managed resources

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -442,11 +442,19 @@ class User extends Authenticatable implements MustVerifyEmail
         }
     }
 
-    public function visibleRolesQuery(string $type): Builder
+    public function visibleRolesQuery(string $type, bool $limitToManaged = false): Builder
     {
         $query = Role::query()
             ->type($type)
             ->where('is_deleted', false);
+
+        if ($limitToManaged) {
+            return $query->whereHas('users', function (Builder $memberQuery) {
+                $memberQuery
+                    ->where('users.id', $this->id)
+                    ->where('role_user.level', '!=', 'follower');
+            });
+        }
 
         if ($this->hasSystemRoleSlug('superadmin')) {
             return $query;


### PR DESCRIPTION
## Summary
- allow role members with non-follower access to view venue/curator/talent listings without system roles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272a1f1a88832e8265e942e1e67165)