### PR TITLE
Hide creation controls without manage permissions

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -7,6 +7,10 @@
     @endphp
     @php
         $creationRoles = collect([$schedules, $venues, $curators])->flatten()->unique('id')->sortBy('name');
+        $canCreateEvent = auth()->user() && (
+            auth()->user()->hasSystemRoleSlug('superadmin') ||
+            (auth()->user()->hasSystemRoleSlug('admin') && auth()->user()->hasPermission('resources.manage'))
+        ) && $creationRoles->isNotEmpty();
         $creationRoleOptions = $creationRoles->map(function ($role) {
             return [
                 'id' => $role->encodeId(),
@@ -127,7 +131,7 @@
                     <div>
                         <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{{ __('messages.events') }}</h2>
                     </div>
-                    @if ($creationRoles->isNotEmpty())
+                    @if ($canCreateEvent)
                         <x-primary-button type="button" x-data="" x-on:click="$dispatch('open-modal', 'create-event')">
                             {{ __('messages.add_event') }}
                         </x-primary-button>
@@ -269,10 +273,10 @@
             'route' => 'home',
             'tab' => '',
             'events' => $calendarEvents,
-            'canCreateEvent' => $creationRoles->isNotEmpty(),
+            'canCreateEvent' => $canCreateEvent,
         ])
 
-        @if ($creationRoles->isNotEmpty())
+        @if ($canCreateEvent)
             <x-modal name="create-event">
                 <div class="px-6 py-5">
                     <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ __('messages.add_event') }}</h2>

--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -134,7 +134,7 @@
                         {{ __('messages.save') }}
                     </button>
                 @endif
-            @elseif ($route == 'home' && auth()->check())
+            @elseif ($route == 'home' && ($canCreateEvent ?? false))
                 <div style="font-family: sans-serif" class="relative inline-block text-left w-full md:w-auto">
                     <button type="button" onclick="onPopUpClick('calendar-pop-up-menu', event)" class="inline-flex w-full justify-center rounded-md bg-white px-4 py-2 text-sm font-semibold text-gray-500 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" id="menu-button" aria-expanded="true" aria-haspopup="true">
                         {{ __('messages.new_schedule') }}


### PR DESCRIPTION
## Summary
- gate home page event creation controls behind manage permissions
- only render schedule creation dropdown when users can create events

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3f4ca650832e8558a37898e1b938)