### PR TITLE
Fix password validation closure signatures

### DIFF
--- a/app/Http/Controllers/UserManagementController.php
+++ b/app/Http/Controllers/UserManagementController.php
@@ -61,7 +61,7 @@ class UserManagementController extends Controller
             'email' => ['required', 'string', 'email', 'max:255', Rule::unique(User::class, 'email')],
             'password_mode' => ['required', Rule::in(['set', 'invite', 'defer'])],
             'password' => [
-                Rule::requiredIf(fn ($input) => $input->password_mode === 'set'),
+                Rule::requiredIf(fn () => $request->input('password_mode') === 'set'),
                 'nullable',
                 'string',
                 'min:8',
@@ -137,7 +137,7 @@ class UserManagementController extends Controller
             'email' => ['required', 'string', 'email', 'max:255', Rule::unique(User::class, 'email')->ignore($user->getKey())],
             'password_mode' => ['required', Rule::in(['set', 'invite', 'defer'])],
             'password' => [
-                Rule::requiredIf(fn ($input) => $input->password_mode === 'set'),
+                Rule::requiredIf(fn () => $request->input('password_mode') === 'set'),
                 'nullable',
                 'string',
                 'min:8',


### PR DESCRIPTION
## Summary
- update password required rules to use zero-argument closures compatible with Laravel
- ensure password requirement checks password_mode value from the current request

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e588f4d94832eb5e44c911336b542)