### PR TITLE
Ensure superadmins can manage venues

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -352,6 +352,10 @@ class User extends Authenticatable implements MustVerifyEmail, CanResetPasswordC
 
     public function isAdmin(): bool
     {
+        if ($this->hasSystemRoleSlug('superadmin')) {
+            return true;
+        }
+
         if ($this->hasPermission('settings.manage') || $this->hasPermission('resources.manage')) {
             return true;
         }


### PR DESCRIPTION
## Summary
- treat superadmins as admins in the isAdmin helper so hosted/admin checks allow access

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0206fde0832e8af8087fce603c3d)