### PR TITLE
Broaden eligible team member list

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -653,17 +653,13 @@ class RoleController extends Controller
 
     protected function eligibleTeamMembers(Role $role)
     {
-        $scopeColumn = $role->type . '_scope';
-        $idsColumn = $role->type . '_ids';
-
         return User::query()
             ->with('systemRoles')
             ->whereHas('systemRoles', function ($query) {
                 $query->whereIn('slug', ['admin', 'viewer']);
             })
-            ->where(function (Builder $query) use ($scopeColumn, $idsColumn, $role) {
-                $query->where($scopeColumn, 'all')
-                    ->orWhereJsonContains($idsColumn, $role->id);
+            ->whereDoesntHave('roles', function (Builder $query) use ($role) {
+                $query->where('roles.id', $role->id);
             })
             ->orderBy('name')
             ->orderBy('email')


### PR DESCRIPTION
## Summary
- include admins and viewers who are not already on the team when adding a member
- remove resource scope requirement so newly created users can be selected for team membership

## Testing
- php artisan test *(fails: vendor dependencies missing in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2529fed4832ebfcdfadb71087bea)