### PR TITLE
Ensure viewer level in base role_user schema

### DIFF
--- a/database/migrations/2024_07_13_184927_setup_database.php
+++ b/database/migrations/2024_07_13_184927_setup_database.php
@@ -64,7 +64,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->foreignId('role_id')->constrained()->onDelete('cascade');
-            $table->enum('level', ['owner', 'admin', 'follower'])->index();
+            $table->enum('level', ['owner', 'admin', 'viewer', 'follower'])->index();
             $table->timestamps();
             $table->unique(['user_id', 'role_id']);
         });

--- a/database/migrations/2025_02_06_000001_add_viewer_role_level.php
+++ b/database/migrations/2025_02_06_000001_add_viewer_role_level.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE `role_user` MODIFY `level` ENUM('owner','admin','viewer','follower') NOT NULL");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE `role_user` MODIFY `level` ENUM('owner','admin','follower') NOT NULL");
+    }
+};


### PR DESCRIPTION
## Summary
- update the initial role_user table definition to include the viewer level so new databases accept viewer memberships

## Testing
- not run (vendor dependencies unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2be46b5c832eb0981aea3016f2b0)