### PR TITLE
Fix calendar route base params initialization

### DIFF
--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -194,6 +194,7 @@
                 'month' => now()->month,
             ]);
 
+            $roleBaseParams = [];
             if (in_array($route, ['guest', 'admin'])) {
                 $roleBaseParams = ['subdomain' => $role->subdomain];
                 if ($route === 'guest') {


### PR DESCRIPTION
## Summary
- initialize default role base parameters before resolving calendar navigation routes to avoid undefined variable errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932282bf360832e95ed89a6dd62aedd)