### PR TITLE
Use failover mailer by default

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -14,7 +14,7 @@ return [
     |
     */
 
-    'default' => env('MAIL_MAILER', 'log'),
+    'default' => env('MAIL_MAILER', 'failover'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- switch the default mailer to Laravel's failover driver so email attempts fall back to logging when SMTP is unavailable

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69322a7c7cac832e9184c0a9a4b0752b)