### PR TITLE
Add CSP nonce to calendar Vue script

### DIFF
--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -482,7 +482,7 @@
 
 <div id="tooltip" class="tooltip"></div>
 
-<script src="{{ asset('js/vue.global.prod.js') }}"></script>
+<script src="{{ asset('js/vue.global.prod.js') }}" {!! nonce_attr() !!}></script>
 <script {!! nonce_attr() !!}>
 const { createApp } = Vue;
 


### PR DESCRIPTION
## Summary
- add CSP nonce to the external Vue calendar script to allow it to load under strict CSP

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693237991258832ea8df0c91969bb7c7)