### PR TITLE
Fix calendar dropdown bindings to avoid Vue errors

### DIFF
--- a/resources/views/role/partials/calendar.blade.php
+++ b/resources/views/role/partials/calendar.blade.php
@@ -245,18 +245,18 @@
             </a>
 
             <div class="relative" x-data="{ open: false }">
-                <button type="button" @click="open = !open" :aria-expanded="open.toString()" class="flex h-9 items-center gap-2 rounded-md border border-gray-200 px-3 text-sm font-semibold text-gray-900 transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800">
+                <button type="button" x-on:click="open = !open" x-bind:aria-expanded="open.toString()" class="flex h-9 items-center gap-2 rounded-md border border-gray-200 px-3 text-sm font-semibold text-gray-900 transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800">
                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l3 3" />
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     <span>{{ __('messages.this_month') }}</span>
-                    <svg class="h-4 w-4 transition" :class="{ 'rotate-180': open }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <svg class="h-4 w-4 transition" x-bind:class="{ 'rotate-180': open }" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
                     </svg>
                 </button>
 
-                <div x-show="open" x-cloak @click.outside="open = false" class="absolute left-0 z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
+                <div x-show="open" x-cloak x-on:click.outside="open = false" class="absolute left-0 z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-100 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
                     <div class="max-h-64 overflow-y-auto py-2">
                         @foreach($monthOptions as $option)
                             <a href="{{ $option['url'] }}" class="flex items-center justify-between px-3 py-2 text-sm text-gray-700 transition hover:bg-gray-50 dark:text-gray-200 dark:hover:bg-gray-800">


### PR DESCRIPTION
## Summary
- switch calendar month selector bindings to Alpine-specific attributes to avoid Vue evaluation errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69323dfb4b74832ea39954d36fb99411)