### PR TITLE
Alphabetize settings cards

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -15,15 +15,15 @@
                         </header>
 
                         <div class="mt-6 grid gap-6 sm:grid-cols-2">
-                            <a href="{{ route('settings.general') }}"
+                            <a href="{{ route('settings.branding') }}"
                                class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
                                 <div class="flex items-start justify-between gap-3">
                                     <div>
                                         <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.general_settings') }}
+                                            {{ __('messages.branding_settings_heading') }}
                                         </h3>
                                         <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.general_settings_description') }}
+                                            {{ __('messages.branding_settings_description') }}
                                         </p>
                                     </div>
                                     <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
@@ -37,59 +37,15 @@
                                 </span>
                             </a>
 
-                            <a href="{{ route('settings.users.index') }}"
+                            <a href="{{ route('settings.email') }}"
                                class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
                                 <div class="flex items-start justify-between gap-3">
                                     <div>
                                         <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.user_management') }}
+                                            {{ __('messages.email_settings') }}
                                         </h3>
                                         <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.user_management_short_description') }}
-                                        </p>
-                                    </div>
-                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
-                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                                        </svg>
-                                    </span>
-                                </div>
-                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
-                                    {{ __('messages.view_details') }}
-                                </span>
-                            </a>
-
-                            <a href="{{ route('settings.updates') }}"
-                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
-                                <div class="flex items-start justify-between gap-3">
-                                    <div>
-                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.update_settings') }}
-                                        </h3>
-                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.update_settings_short_description') }}
-                                        </p>
-                                    </div>
-                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
-                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                                        </svg>
-                                    </span>
-                                </div>
-                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
-                                    {{ __('messages.view_details') }}
-                                </span>
-                            </a>
-
-                            <a href="{{ route('settings.logging') }}"
-                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
-                                <div class="flex items-start justify-between gap-3">
-                                    <div>
-                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.logging_settings') }}
-                                        </h3>
-                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.logging_settings_short_description') }}
+                                            {{ __('messages.email_settings_combined_description') }}
                                         </p>
                                     </div>
                                     <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
@@ -125,15 +81,15 @@
                                 </span>
                             </a>
 
-                            <a href="{{ route('settings.branding') }}"
+                            <a href="{{ route('settings.general') }}"
                                class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
                                 <div class="flex items-start justify-between gap-3">
                                     <div>
                                         <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.branding_settings_heading') }}
+                                            {{ __('messages.general_settings') }}
                                         </h3>
                                         <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.branding_settings_description') }}
+                                            {{ __('messages.general_settings_description') }}
                                         </p>
                                     </div>
                                     <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
@@ -169,28 +125,6 @@
                                 </span>
                             </a>
 
-                            <a href="{{ route('settings.terms') }}"
-                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
-                                <div class="flex items-start justify-between gap-3">
-                                    <div>
-                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.terms_settings') }}
-                                        </h3>
-                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.terms_settings_description') }}
-                                        </p>
-                                    </div>
-                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
-                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                                        </svg>
-                                    </span>
-                                </div>
-                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
-                                    {{ __('messages.view_details') }}
-                                </span>
-                            </a>
-
                             <a href="{{ route('settings.integrations') }}"
                                class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
                                 <div class="flex items-start justify-between gap-3">
@@ -213,15 +147,15 @@
                                 </span>
                             </a>
 
-                            <a href="{{ route('settings.wallet') }}"
+                            <a href="{{ route('settings.logging') }}"
                                class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
                                 <div class="flex items-start justify-between gap-3">
                                     <div>
                                         <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.wallet_settings') }}
+                                            {{ __('messages.logging_settings') }}
                                         </h3>
                                         <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.wallet_settings_description') }}
+                                            {{ __('messages.logging_settings_short_description') }}
                                         </p>
                                     </div>
                                     <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
@@ -235,15 +169,81 @@
                                 </span>
                             </a>
 
-                            <a href="{{ route('settings.email') }}"
+                            <a href="{{ route('settings.terms') }}"
                                class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
                                 <div class="flex items-start justify-between gap-3">
                                     <div>
                                         <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
-                                            {{ __('messages.email_settings') }}
+                                            {{ __('messages.terms_settings') }}
                                         </h3>
                                         <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                            {{ __('messages.email_settings_combined_description') }}
+                                            {{ __('messages.terms_settings_description') }}
+                                        </p>
+                                    </div>
+                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
+                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                                        </svg>
+                                    </span>
+                                </div>
+                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
+                                    {{ __('messages.view_details') }}
+                                </span>
+                            </a>
+
+                            <a href="{{ route('settings.updates') }}"
+                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
+                                            {{ __('messages.update_settings') }}
+                                        </h3>
+                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                            {{ __('messages.update_settings_short_description') }}
+                                        </p>
+                                    </div>
+                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
+                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                                        </svg>
+                                    </span>
+                                </div>
+                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
+                                    {{ __('messages.view_details') }}
+                                </span>
+                            </a>
+
+                            <a href="{{ route('settings.users.index') }}"
+                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
+                                            {{ __('messages.user_management') }}
+                                        </h3>
+                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                            {{ __('messages.user_management_short_description') }}
+                                        </p>
+                                    </div>
+                                    <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">
+                                        <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                                        </svg>
+                                    </span>
+                                </div>
+                                <span class="mt-auto text-sm font-medium text-[#4E81FA]">
+                                    {{ __('messages.view_details') }}
+                                </span>
+                            </a>
+
+                            <a href="{{ route('settings.wallet') }}"
+                               class="group flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-6 transition hover:border-[#4E81FA] hover:shadow dark:border-gray-700 dark:bg-gray-800 dark:hover:border-[#4E81FA]">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div>
+                                        <h3 class="text-base font-semibold text-gray-900 transition group-hover:text-[#4E81FA] dark:text-gray-100">
+                                            {{ __('messages.wallet_settings') }}
+                                        </h3>
+                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                            {{ __('messages.wallet_settings_description') }}
                                         </p>
                                     </div>
                                     <span class="text-gray-300 transition group-hover:text-[#4E81FA] dark:text-gray-600">


### PR DESCRIPTION
## Summary
- reorder settings overview cards in alphabetical order for easier scanning

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69324ef39cbc832eaf4db136188ebc36)