### PR TITLE
Add active middleware alias

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 use App\Console\Commands\InspectStoragePermissions;
 use App\Http\Middleware\SetUserLanguage;
 use App\Http\Middleware\EnsureEmailIsVerified;
+use App\Http\Middleware\EnsureUserIsActive;
 use App\Http\Middleware\HandleBotTraffic;
 use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\ApiAuthentication;
@@ -26,6 +27,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'api.auth' => ApiAuthentication::class,
             'ability' => EnsureAbility::class,
+            'active' => EnsureUserIsActive::class,
         ]);
 
         $middleware->validateCsrfTokens(except: [


### PR DESCRIPTION
## Summary
- register the `active` middleware alias in the bootstrap middleware configuration so routes using it resolve correctly

## Testing
- composer install (fails: network restriction fetching dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932dabd4370832eb74053aa8f59b041)