### PR TITLE
Add migration to ensure users table supports soft deletes

### DIFF
--- a/database/migrations/2026_10_25_000200_add_soft_deletes_column_to_users_table.php
+++ b/database/migrations/2026_10_25_000200_add_soft_deletes_column_to_users_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'status')) {
+                $table->string('status')->default('active')->after('language_code');
+            }
+
+            if (! Schema::hasColumn('users', 'deleted_at')) {
+                $table->softDeletes();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+
+            if (Schema::hasColumn('users', 'status')) {
+                $table->dropColumn('status');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that adds missing `status` and `deleted_at` columns to the users table when absent
- ensure rollback drops the columns only if they exist

## Testing
- php artisan test --env=testing *(fails: missing vendor/autoload.php)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e68adc6c832e9686b309dad060b2)