### PR TITLE
Add migration for users soft deletes column

### DIFF
--- a/database/migrations/2026_10_30_000300_add_deleted_at_to_users_table.php
+++ b/database/migrations/2026_10_30_000300_add_deleted_at_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'deleted_at')) {
+                $table->softDeletes();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that adds the users.deleted_at column when it is missing to support soft deletes
- include a guarded rollback that removes the soft delete column only if present

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932eaf27660832ebcfe52b2e0ddf2d5)