### PR TITLE
Add migration to ensure users soft deletes column exists

### DIFF
--- a/database/migrations/2026_10_31_000400_add_missing_deleted_at_to_users_table.php
+++ b/database/migrations/2026_10_31_000400_add_missing_deleted_at_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'deleted_at')) {
+                $table->softDeletes();
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'deleted_at')) {
+                $table->dropSoftDeletes();
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration that adds the missing `deleted_at` column to the users table when absent to support soft deletes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f492cd58832ebaf4f3319964bcf2)