### PR TITLE
Guard rollback of users soft deletes migration

### DIFF
--- a/database/migrations/2026_10_31_000400_add_missing_deleted_at_to_users_table.php
+++ b/database/migrations/2026_10_31_000400_add_missing_deleted_at_to_users_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -23,10 +24,33 @@ return new class extends Migration
      */
     public function down(): void
     {
+        if (! Schema::hasColumn('users', 'deleted_at')) {
+            return;
+        }
+
+        if ($this->deletedAtColumnPreexisted()) {
+            return;
+        }
+
         Schema::table('users', function (Blueprint $table) {
-            if (Schema::hasColumn('users', 'deleted_at')) {
-                $table->dropSoftDeletes();
-            }
+            $table->dropSoftDeletes();
         });
+    }
+
+    private function deletedAtColumnPreexisted(): bool
+    {
+        if (! Schema::hasTable('migrations')) {
+            return false;
+        }
+
+        $priorSoftDeleteMigrations = [
+            '2026_10_20_000100_add_status_and_soft_deletes_to_users_table',
+            '2026_10_25_000200_add_soft_deletes_column_to_users_table',
+            '2026_10_30_000300_add_deleted_at_to_users_table',
+        ];
+
+        return DB::table('migrations')
+            ->whereIn('migration', $priorSoftDeleteMigrations)
+            ->exists();
     }
 };


### PR DESCRIPTION
## Summary
- guard the rollback from dropping an existing users.deleted_at column that predated this migration
- add a helper to detect prior soft delete migrations before attempting to remove the column

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f942ae7c832e966e5331c3eeb9f1)