### PR TITLE
Allow superadmin login when status missing or inactive

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -165,7 +165,11 @@ class User extends Authenticatable implements MustVerifyEmail, CanResetPasswordC
 
     public function isActive(): bool
     {
-        return $this->status === 'active' && ! $this->trashed();
+        if ($this->hasSystemRoleSlug('superadmin')) {
+            return ! $this->trashed();
+        }
+
+        return ($this->status ?? 'active') === 'active' && ! $this->trashed();
     }
 
     public function hasSystemRoleSlug(string $slug): bool


### PR DESCRIPTION
## Summary
- allow superadmin users to bypass status checks when determining account activity
- treat missing user status values as active to avoid locking the only administrative account

## Testing
- ⚠️ `phpunit --filter UserTest --testsuite Unit` *(PHPUnit binary not available in environment)*
- ⚠️ `./vendor/bin/phpunit --filter User --testsuite Unit` *(PHPUnit binary not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69333e573458832eb53901b2f126d569)