### PR TITLE
Show settings link for users with settings permission

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -314,7 +314,7 @@
         </li>
 
 
-        @if (auth()->user()->hasSystemRoleSlug('superadmin'))
+        @if (auth()->user()->hasPermission('settings.manage'))
         <li class="mt-auto">
             <a href="{{ route('settings.index') }}"
                 class="{{ $navLinkBase }} -mx-2 font-semibold {{ request()->is('settings*') ? $navLinkActive : $navLinkDefault }}">


### PR DESCRIPTION
## Summary
- show the settings navigation link to anyone with the settings.manage permission so super admins can access it

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334585d114832e9b131fb459087ed0)