### PR TITLE
Add discovery endpoints for EventSchedule mobile configuration

### DIFF
--- a/app/Http/Controllers/DiscoveryController.php
+++ b/app/Http/Controllers/DiscoveryController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+
+class DiscoveryController extends Controller
+{
+    public function manifest(): JsonResponse
+    {
+        return response()->json([
+            'apiBaseURL' => url('/api'),
+            'brandingEndpoint' => url('/branding.json'),
+            'features' => ['branding'],
+        ]);
+    }
+
+    public function branding(): JsonResponse
+    {
+        $branding = config('branding', []);
+
+        return response()->json([
+            'logoUrl' => data_get($branding, 'logo_url', branding_logo_url()),
+            'logoAlt' => data_get($branding, 'logo_alt', 'Event Schedule'),
+            'colors' => [
+                'primary' => data_get($branding, 'colors.primary', '#1F2937'),
+                'secondary' => data_get($branding, 'colors.secondary', '#111827'),
+                'tertiary' => data_get($branding, 'colors.tertiary', '#374151'),
+                'onPrimary' => data_get($branding, 'colors.on_primary', '#FFFFFF'),
+                'onSecondary' => data_get($branding, 'colors.on_secondary', '#FFFFFF'),
+                'onTertiary' => data_get($branding, 'colors.on_tertiary', '#FFFFFF'),
+            ],
+            'defaultLanguage' => data_get($branding, 'default_language', config('app.locale', 'en')),
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\InvoiceNinjaController;
 use App\Http\Controllers\AppController;
 use App\Http\Controllers\Api\ApiSettingsController;
 use App\Http\Controllers\TermsController;
+use App\Http\Controllers\DiscoveryController;
 use App\Http\Controllers\BlogController;
 use App\Http\Controllers\GoogleCalendarController;
 use App\Http\Controllers\GoogleCalendarWebhookController;
@@ -74,6 +75,10 @@ Route::post('/unsubscribe', [RoleController::class, 'unsubscribe'])
 Route::get('/user/unsubscribe', [RoleController::class, 'unsubscribeUser'])
     ->name('user.unsubscribe')
     ->middleware('throttle:2,2');
+Route::get('/.well-known/eventschedule.json', [DiscoveryController::class, 'manifest'])
+    ->name('well_known.eventschedule');
+Route::get('/branding.json', [DiscoveryController::class, 'branding'])
+    ->name('branding.json');
 Route::post('/clear-pending-request', [EventController::class, 'clearPendingRequest'])->name('event.clear_pending_request');
 
 Route::get('/terms', [TermsController::class, 'show'])->name('terms.show');

--- a/tests/Feature/DiscoveryEndpointsTest.php
+++ b/tests/Feature/DiscoveryEndpointsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class DiscoveryEndpointsTest extends TestCase
+{
+    public function test_manifest_is_available_at_well_known_path(): void
+    {
+        $response = $this->getJson('/.well-known/eventschedule.json');
+
+        $response->assertOk()
+            ->assertJson([
+                'apiBaseURL' => url('/api'),
+                'brandingEndpoint' => url('/branding.json'),
+            ])
+            ->assertJsonStructure([
+                'apiBaseURL',
+                'brandingEndpoint',
+                'features',
+            ]);
+    }
+
+    public function test_branding_endpoint_returns_resolved_branding_settings(): void
+    {
+        config()->set('branding', [
+            'logo_url' => 'https://example.com/logo.png',
+            'logo_alt' => 'Example Logo',
+            'colors' => [
+                'primary' => '#123456',
+                'secondary' => '#654321',
+                'tertiary' => '#abcdef',
+                'on_primary' => '#0F0F0F',
+                'on_secondary' => '#111111',
+                'on_tertiary' => '#222222',
+            ],
+            'default_language' => 'fr',
+        ]);
+
+        $response = $this->getJson('/branding.json');
+
+        $response->assertOk()->assertJson([
+            'logoUrl' => 'https://example.com/logo.png',
+            'logoAlt' => 'Example Logo',
+            'colors' => [
+                'primary' => '#123456',
+                'secondary' => '#654321',
+                'tertiary' => '#abcdef',
+                'onPrimary' => '#0F0F0F',
+                'onSecondary' => '#111111',
+                'onTertiary' => '#222222',
+            ],
+            'defaultLanguage' => 'fr',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a well-known discovery manifest that points mobile clients to the API base URL and branding endpoint
- expose branding details as a public JSON response for mobile theming
- cover the new discovery and branding endpoints with feature tests

## Testing
- not run (vendor directory missing in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935bd589f70832e93796c7c101fa3a2)