### PR TITLE
Handle venue association without venue_id column

### DIFF
--- a/app/Repos/EventRepo.php
+++ b/app/Repos/EventRepo.php
@@ -222,6 +222,10 @@ class EventRepo
 
             $input = $request->all();
 
+            // Prevent attempting to persist legacy venue_id column; venue linkage is
+            // handled via the pivot table instead.
+            $input = Arr::except($input, ['venue_id']);
+
             if (array_key_exists('slug', $input)) {
                 $slugValue = $input['slug'];
 


### PR DESCRIPTION
## Summary
- avoid persisting the legacy `venue_id` column when saving events
- keep venue linkage managed through the event-role pivot

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69383651cd20832e8a7f91de4483224f)