### PR TITLE
Allow editing venues, curators, and talent on event update

### DIFF
--- a/docs/MOBILE_EVENTS_UPDATE_NOTES.md
+++ b/docs/MOBILE_EVENTS_UPDATE_NOTES.md
@@ -3,29 +3,31 @@
 This memo summarizes the current backend behavior around updating events via the public API.
 
 ## 1. Update endpoint contract
-- There is **no API route** registered for updating events. The only event write endpoints are `POST /api/events/{subdomain}` (create) and `POST /api/events/flyer/{event_id}` (flyer upload/replacement). 【F:routes/api.php†L16-L22】
-- Because no update route exists, there is no supported method/path, no minimal JSON body, and partial updates are not available.
+- New route: `PATCH /api/events/{event_id}` guarded by the `resources.manage` ability. It requires ownership of the event (`event.user_id === auth()->id()`) and returns 403 otherwise. 【F:routes/api.php†L16-L22】【F:app/Http/Controllers/Api/ApiEventController.php†L231-L242】
+- Minimal payload: send only the fields you want to change. `name` and `starts_at` remain required **only when provided**, and at least one of `venue_id`, `venue_address1`, or `event_url` must be present if any of them are supplied. 【F:app/Http/Controllers/Api/ApiEventController.php†L244-L254】
+- Successful updates return the fully refreshed event object plus `meta.message: "Event updated successfully"`. 【F:app/Http/Controllers/Api/ApiEventController.php†L316-L320】
 
 ## 2. Role fields on update
-- Not applicable—update is not implemented. Event creation sets `venue_id`, `members`, and curator membership automatically based on the subdomain and request body. 【F:app/Http/Controllers/Api/ApiEventController.php†L70-L213】
+- If no role fields are provided, the backend preserves existing venue, member, and curator relationships by seeding the request with current values before persisting. When role arrays are provided, the update logic merges them with existing associations so mobile clients can add, edit, or prune venue/curator/talent links without reconstructing the full roster. 【F:app/Http/Controllers/Api/ApiEventController.php†L281-L316】
+- When a `schedule` slug is supplied, it is resolved against the updater's `currentRole` groups; unknown slugs return 422. 【F:app/Http/Controllers/Api/ApiEventController.php†L256-L268】
 
 ## 3. Validation rules for role IDs
-- Not applicable for updates. Creation validates venue fields (`venue_id` or address/url) and resolves member role IDs within the authenticated user’s roles. 【F:app/Http/Controllers/Api/ApiEventController.php†L85-L213】
+- `venue_id` remains optional but must accompany `venue_address1`/`event_url` rules when those fields are present. Category name slugs are resolved the same way as creation, with a 422 response when no match is found. 【F:app/Http/Controllers/Api/ApiEventController.php†L244-L298】
+- Member and curator arrays accept encoded role IDs; existing associations are retained when omitted thanks to the preservation step noted above. 【F:app/Http/Controllers/Api/ApiEventController.php†L281-L314】
 
 ## 4. Error semantics
-- The codebase does not surface field-specific errors for a nonexistent update route. Creation returns validation errors (HTTP 422) when schedule/group/category lookups fail and 403 when the authenticated user is not a member of the target subdomain. 【F:app/Http/Controllers/Api/ApiEventController.php†L72-L156】【F:app/Http/Controllers/Api/ApiEventController.php†L81-L83】
+- 403 when the authenticated user does not own the event. 422 when schedule slugs or category names cannot be resolved, or when validation rules for venue fields fail. 404 when the event ID is unknown. 【F:app/Http/Controllers/Api/ApiEventController.php†L231-L242】【F:app/Http/Controllers/Api/ApiEventController.php†L256-L299】
 
 ## 5. Create vs. update differences
-- Only creation is supported via the API; there is no update payload to compare. Any differences that exist are between creation and flyer upload handling.
+- Creation infers venue/talent/curator defaults from the `{subdomain}` path parameter. Updates omit the subdomain and instead reuse the event's creator/linked roles, preserving existing associations unless new arrays are provided. 【F:app/Http/Controllers/Api/ApiEventController.php†L70-L220】【F:app/Http/Controllers/Api/ApiEventController.php†L231-L314】
 
 ## 6. Include/expand parameters
-- Not applicable for updates. Existing event endpoints do not implement `include` query handling. 【F:routes/api.php†L16-L22】【F:app/Http/Controllers/Api/ApiEventController.php†L19-L67】
+- No include/expand parameters are implemented; responses always return the full event payload through `toApiData()`. 【F:app/Http/Controllers/Api/ApiEventController.php†L316-L320】【F:app/Models/Event.php†L808-L876】
 
 ## 7. Versioning and rollout
-- There has been no route change from PUT/PATCH/POST for updates because an update route has not been added yet.
+- First introduction of `PATCH /api/events/{event_id}`; no version gating is present.
 
 ## Example requests (available today)
 - **Create event:** `POST /api/events/{subdomain}` with `name`, `starts_at`, and venue/address/url per the creation validation rules. 【F:docs/MOBILE_EVENTS_API_GUIDE.md†L68-L160】
-- **Upload/replace flyer:** `POST /api/events/flyer/{event_id}` to set or clear `flyer_image_id`, or upload a `flyer_image` file. 【F:app/Http/Controllers/Api/ApiEventController.php†L215-L289】
-
-If an update endpoint is introduced in the future, its method, payload, and validation rules will need to be defined and documented; currently the API only supports creation and flyer upload for events.
+- **Update event:** `PATCH /api/events/{event_id}` with any editable fields (e.g., `{"name": "New title", "starts_at": "2024-05-01 20:00:00"}`); omitted venue/members/curators remain unchanged. 【F:app/Http/Controllers/Api/ApiEventController.php†L244-L320】
+- **Upload/replace flyer:** `POST /api/events/flyer/{event_id}` to set or clear `flyer_image_id`, or upload a `flyer_image` file. 【F:app/Http/Controllers/Api/ApiEventController.php†L330-L395】

--- a/docs/mobile-event-requirements.md
+++ b/docs/mobile-event-requirements.md
@@ -36,35 +36,10 @@ The mobile client must only surface the same fields and actions that appear on t
 - Primary actions: Save and Cancel; Delete is available when editing an existing event. 【F:resources/views/event/edit.blade.php†L1046-L1060】
 - Google Calendar sync controls for existing events linked to a Google account: show sync status, and buttons to sync or remove from Google Calendar. 【F:resources/views/event/edit.blade.php†L1062-L1095】
 
-## Open questions for the web API
-The mobile client needs clarification on how to mirror web update behavior while avoiding hidden logic. Please confirm the following:
+## Web API update expectations (resolved)
+The backend now exposes `PATCH /api/events/{event_id}` for edits. Key behaviors the mobile client should mirror:
 
-1. **Update endpoint contract**
-   - Expected HTTP method and path for updates (e.g., `PATCH /api/events/{id}`).
-   - Minimal valid payload for basic edits (name, description, dates) with a working example JSON body.
-   - Whether partial updates are supported and which fields are optional/omittable.
-
-2. **Role fields on update (venue, members, curator)**
-   - Whether `venue_id` should be included when updating; if the event was created under a venue subdomain, should it be omitted?
-   - If `venue_id` is included but unchanged, is that allowed?
-   - How to update participants: does the endpoint accept a `members` array of role IDs, or is there a separate add/remove API? If accepted, should the client send full replacements or diffs?
-   - Any other role-based fields (e.g., `curator_role_id`) that must be included or omitted on update.
-
-3. **Validation rules for role IDs**
-   - Valid sources of `venue_id` during edits (must it belong to the same schedule/subdomain? can events be reassigned?).
-   - Accepted role types for `members`, and whether member IDs must belong to the same schedule/subdomain.
-   - Constraints that could trigger `"No query results for model [App\Models\Role]"` when IDs exist in another context.
-
-4. **Error semantics**
-   - When `"No query results for model [App\Models\Role]"` occurs, which field is being resolved (venue, members, curator)?
-   - Whether the server can return field-specific errors (e.g., `errors: { venue_id: ["not found"] }`).
-   - Whether logs or middleware can reveal which specific ID failed lookup.
-
-5. **Create vs update differences**
-   - Intentional differences between create and update payloads (e.g., create accepts `members` but update does not; create infers venue from subdomain while update expects no `venue_id`).
-
-6. **Include/expand parameters**
-   - Whether `include=venue,talent,tickets` (or similar) is supported on update responses and which include values are allowed.
-
-7. **Versioning and rollout**
-   - Recent changes to the update route (e.g., method switched from PUT to POST) and whether clients need gating based on API version or capabilities.
+1. **Endpoint contract** — Ownership required; otherwise 403. Partial payloads are allowed; `name`/`starts_at` become required only when present, and venue/address/url fields keep the required-without-all rule when any are supplied. 【F:routes/api.php†L16-L22】【F:app/Http/Controllers/Api/ApiEventController.php†L231-L254】
+2. **Role fields** — Existing venue, members, and curators are preserved when omitted; providing new arrays merges with current associations so the client can add/edit/remove talent, curators, or venues without rebuilding the full list. Schedule slugs are resolved to `current_role_group_id` or return 422 if unknown. 【F:app/Http/Controllers/Api/ApiEventController.php†L256-L316】
+3. **Validation and errors** — Category slugs map to IDs; unknown categories or schedule slugs return 422. Unknown event IDs return 404. 【F:app/Http/Controllers/Api/ApiEventController.php†L256-L320】
+4. **Create vs update** — Creation infers defaults from `{subdomain}`; updates reuse the existing event’s roles and keep associations unless explicitly changed. Responses always return the full `toApiData()` payload. 【F:app/Http/Controllers/Api/ApiEventController.php†L70-L220】【F:app/Http/Controllers/Api/ApiEventController.php†L231-L320】【F:app/Models/Event.php†L808-L876】

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,5 +18,6 @@ Route::middleware([ApiAuthentication::class])->group(function () {
     Route::get('/events', [ApiEventController::class, 'index'])->middleware('ability:resources.view');
     Route::get('/events/resources', [ApiEventController::class, 'resources'])->middleware('ability:resources.view');
     Route::post('/events/{subdomain}', [ApiEventController::class, 'store'])->middleware('ability:resources.manage');
+    Route::patch('/events/{event_id}', [ApiEventController::class, 'update'])->middleware('ability:resources.manage');
     Route::post('/events/flyer/{event_id}', [ApiEventController::class, 'flyer'])->middleware('ability:resources.view');
 });


### PR DESCRIPTION
## Summary
- merge members and curators with existing associations during PATCH so venue/talent/curator edits don’t require resending the full roster
- clarify update semantics in the API reference, mobile API guide, update notes, and mobile requirements documentation

## Testing
- php -l app/Http/Controllers/Api/ApiEventController.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384837e090832eae77da714d4862c4)