### PR TITLE
Add API delete endpoints for events and roles

### DIFF
--- a/app/Http/Controllers/Api/ApiEventController.php
+++ b/app/Http/Controllers/Api/ApiEventController.php
@@ -398,6 +398,23 @@ class ApiEventController extends Controller
         ], 200, [], JSON_PRETTY_PRINT);
     }
 
+    public function destroy(Request $request, $event_id)
+    {
+        $event = Event::findOrFail(UrlUtils::decodeId($event_id));
+
+        if ($event->user_id !== auth()->id()) {
+            return response()->json(['error' => 'Unauthorized'], 403);
+        }
+
+        $event->delete();
+
+        return response()->json([
+            'meta' => [
+                'message' => 'Event deleted successfully'
+            ]
+        ], 200, [], JSON_PRETTY_PRINT);
+    }
+
     public function flyer(Request $request, $event_id)
     {
         $event = Event::findOrFail(UrlUtils::decodeId($event_id));

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,10 +14,13 @@ Route::middleware([ApiAuthentication::class])->group(function () {
 
     Route::get('/roles', [ApiRoleController::class, 'index'])->middleware('ability:resources.view');
     Route::post('/roles', [ApiRoleController::class, 'store'])->middleware('ability:resources.manage');
+    Route::delete('/roles/{role_id}', [ApiRoleController::class, 'destroy'])->middleware('ability:resources.manage');
+    Route::delete('/roles/{role_id}/contacts/{contact}', [ApiRoleController::class, 'destroyContact'])->middleware('ability:resources.manage');
 
     Route::get('/events', [ApiEventController::class, 'index'])->middleware('ability:resources.view');
     Route::get('/events/resources', [ApiEventController::class, 'resources'])->middleware('ability:resources.view');
     Route::post('/events/{subdomain}', [ApiEventController::class, 'store'])->middleware('ability:resources.manage');
     Route::patch('/events/{event_id}', [ApiEventController::class, 'update'])->middleware('ability:resources.manage');
+    Route::delete('/events/{event_id}', [ApiEventController::class, 'destroy'])->middleware('ability:resources.manage');
     Route::post('/events/flyer/{event_id}', [ApiEventController::class, 'flyer'])->middleware('ability:resources.view');
 });


### PR DESCRIPTION
## Summary
- add DELETE routes for events, roles, and role contacts in the API
- implement event deletion and role/contact removal handlers with ownership checks
- ensure talent deletion cleans up single-member events

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693862c52b58832e8d85d9df44475fe2)