### PR TITLE
Ensure mobile event API date formatting retains local time

### DIFF
--- a/docs/EventFormView.swift
+++ b/docs/EventFormView.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Helper exposed in the mobile event form to normalize dates before hitting the Events API.
+/// Backend expects the `starts_at` payload to reflect the user's local wall time
+/// (no automatic conversion to UTC), so we keep the formatter on `.current`.
+struct EventFormView {
+    var selectedDate: Date
+
+    /// Formats the selected date into the `Y-m-d H:i:s` shape expected by the API
+    /// without shifting the wall time to UTC.
+    var apiDateString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.timeZone = .current
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: selectedDate)
+    }
+}

--- a/docs/MOBILE_EVENTS_API_GUIDE.md
+++ b/docs/MOBILE_EVENTS_API_GUIDE.md
@@ -95,7 +95,7 @@ Payload format:
 Creates a new event attached to the schedule identified by `{subdomain}`. The subdomain can be a venue, talent, or curator; the API automatically populates related fields based on the schedule type. **Do not** POST to `/api/events` without a subdomain, as that route is read-only and will return HTTP 405. 【F:app/Http/Controllers/Api/ApiEventController.php†L70-L213】【F:routes/api.php†L14-L20】
 
 Required inputs:
-- `name` (string, ≤255) and `starts_at` (`Y-m-d H:i:s`). 【F:app/Http/Controllers/Api/ApiEventController.php†L85-L95】
+- `name` (string, ≤255) and `starts_at` (`Y-m-d H:i:s`). Backend parsing treats this as the creator's local wall time, not an ISO8601 instant, so mobile clients should format the field in the current timezone rather than forcing UTC. 【F:app/Http/Controllers/Api/ApiEventController.php†L85-L95】【F:app/Repos/EventRepo.php†L237-L243】
 - One of `venue_id`, `venue_address1`, or `event_url`. 【F:app/Http/Controllers/Api/ApiEventController.php†L85-L95】
 
 Key behaviors and optional fields:

--- a/tests/Unit/EventApiDateFormattingTest.php
+++ b/tests/Unit/EventApiDateFormattingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class EventApiDateFormattingTest extends TestCase
+{
+    public function test_local_wall_time_strings_round_trip_across_timezones()
+    {
+        $eventInstantUtc = Carbon::create(2024, 11, 5, 0, 0, 0, 'UTC');
+        $newYorkTz = 'America/New_York';
+        $losAngelesTz = 'America/Los_Angeles';
+
+        $apiStringNewYork = $eventInstantUtc->copy()->setTimezone($newYorkTz)->format('Y-m-d H:i:s');
+        $apiStringLosAngeles = $eventInstantUtc->copy()->setTimezone($losAngelesTz)->format('Y-m-d H:i:s');
+
+        $storedFromNewYork = Carbon::createFromFormat('Y-m-d H:i:s', $apiStringNewYork, $newYorkTz)
+            ->setTimezone('UTC');
+        $storedFromLosAngeles = Carbon::createFromFormat('Y-m-d H:i:s', $apiStringLosAngeles, $losAngelesTz)
+            ->setTimezone('UTC');
+
+        $this->assertSame($eventInstantUtc->toDateTimeString(), $storedFromNewYork->toDateTimeString());
+        $this->assertTrue($storedFromNewYork->equalTo($storedFromLosAngeles));
+    }
+
+    public function test_forcing_utc_in_formatter_shifts_wall_time()
+    {
+        $eventInstantUtc = Carbon::create(2024, 11, 5, 0, 0, 0, 'UTC');
+        $losAngelesTz = 'America/Los_Angeles';
+
+        $apiStringUtc = $eventInstantUtc->copy()->setTimezone('UTC')->format('Y-m-d H:i:s');
+        $storedFromUtc = Carbon::createFromFormat('Y-m-d H:i:s', $apiStringUtc, $losAngelesTz)
+            ->setTimezone('UTC');
+
+        $this->assertNotSame($eventInstantUtc->toDateTimeString(), $storedFromUtc->toDateTimeString());
+        $this->assertNotEquals(
+            $eventInstantUtc->toDateTimeString(),
+            $storedFromUtc->toDateTimeString(),
+            'UTC formatting should reveal the drift when parsed as local time.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- document that `starts_at` values are parsed as local wall time for the mobile API
- add an `EventFormView` helper that formats API date strings with the current timezone
- add a unit test that demonstrates local timezone formatting avoids drift across devices while UTC formatting does not

## Testing
- Not run (PHPUnit binary not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69389b71dde4832e96b1a7adea89ff3e)