### PR TITLE
Normalize starts_at inputs for Events API

### DIFF
--- a/app/Http/Controllers/Api/ApiEventController.php
+++ b/app/Http/Controllers/Api/ApiEventController.php
@@ -10,6 +10,7 @@ use App\Models\Role;
 use App\Models\RoleUser;
 use App\Repos\EventRepo;
 use App\Utils\UrlUtils;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -91,12 +92,14 @@ class ApiEventController extends Controller
     {
         $role = Role::with('groups')->subdomain($subdomain)->firstOrFail();
         $encodedRoleId = UrlUtils::encodeId($role->id);
-        
+
+        $this->normalizeStartsAt($request);
+
         if ($role->isVenue()) {
             $request->merge(['venue_id' => $encodedRoleId]);
         } else if ($role->isTalent()) {
             $request->merge(['members' => [$encodedRoleId => ['name' => $role->name]]]);
-        }   
+        }
 
         if (! auth()->user()->isMember($subdomain)) {
             return response()->json(['error' => 'Unauthorized'], 403);
@@ -249,6 +252,8 @@ class ApiEventController extends Controller
         }
 
         $currentRole = $event->creatorRole ?: $event->roles->first();
+
+        $this->normalizeStartsAt($request);
 
         $validated = $request->validate([
             'name' => 'sometimes|required|string|max:255',
@@ -482,5 +487,22 @@ class ApiEventController extends Controller
                 'message' => 'Flyer uploaded successfully'
             ]
         ], 200, [], JSON_PRETTY_PRINT);
+    }
+
+    protected function normalizeStartsAt(Request $request): void
+    {
+        $startsAt = $request->input('starts_at');
+
+        if (! $startsAt || ! is_string($startsAt)) {
+            return;
+        }
+
+        try {
+            $parsedStartsAt = Carbon::parse($startsAt);
+        } catch (\Throwable $exception) {
+            return;
+        }
+
+        $request->merge(['starts_at' => $parsedStartsAt->format('Y-m-d H:i:s')]);
     }
 }


### PR DESCRIPTION
## Summary
- normalize incoming `starts_at` values for create and update API calls to match expected format
- add shared helper to parse ISO-style timestamps before validation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938c85a1ad4832e8396820bdbf647fb)