### PR TITLE
Redirect event deletion to events list

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -136,13 +136,8 @@ class EventController extends Controller
 
         $this->handleEventDeletion($event, $user);
 
-        $data = [
-            'subdomain' => $subdomain,
-            'tab' => 'schedule',
-        ];
-
-        return redirect(route('role.view_admin', $data))
-                ->with('message', __('messages.event_deleted'));
+        return redirect()->route('home', ['view' => 'list'])
+            ->with('message', __('messages.event_deleted'));
     }
 
     public function destroyFromHome(Request $request, $hash)
@@ -157,7 +152,7 @@ class EventController extends Controller
 
         $this->handleEventDeletion($event, $user);
 
-        return redirect()->route('home')->with('message', __('messages.event_deleted'));
+        return redirect()->route('home', ['view' => 'list'])->with('message', __('messages.event_deleted'));
     }
 
     public function view(Request $request, $hash)


### PR DESCRIPTION
## Summary
- Redirect event deletion flows to return users to the events list view after removal

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6938c93afac0832e8398d5de341fdce2)