### PR TITLE
Add event timezone support and ensure UTC storage

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -433,9 +433,11 @@ class EventController extends Controller
         }
 
         if ($request->date) {
-            $defaultTime = Carbon::now($user->timezone)->setTime(20, 0, 0);
+            $defaultTimezone = $role->timezone ?? $user->timezone ?? config('app.timezone');
+            $defaultTime = Carbon::now($defaultTimezone)->setTime(20, 0, 0);
             $utcTime = $defaultTime->setTimezone('UTC');
             $event->starts_at = $request->date . $utcTime->format('H:i:s');
+            $event->timezone = $defaultTimezone;
         }
 
         $roles = $user->roles()->get();

--- a/app/Http/Requests/EventCreateRequest.php
+++ b/app/Http/Requests/EventCreateRequest.php
@@ -28,6 +28,7 @@ class EventCreateRequest extends FormRequest
             'flyer_media_asset_id' => ['nullable', 'integer', 'exists:media_assets,id'],
             'flyer_media_variant_id' => ['nullable', 'integer', 'exists:media_asset_variants,id'],
             'slug' => ['nullable', 'string', 'max:255'],
+            'timezone' => ['required', 'timezone'],
         ];
     }
 }

--- a/app/Http/Requests/EventUpdateRequest.php
+++ b/app/Http/Requests/EventUpdateRequest.php
@@ -45,6 +45,7 @@ class EventUpdateRequest extends FormRequest
             'flyer_media_asset_id' => ['nullable', 'integer', 'exists:media_assets,id'],
             'flyer_media_variant_id' => ['nullable', 'integer', 'exists:media_asset_variants,id'],
             'slug' => ['nullable', 'string', 'max:255'],
+            'timezone' => ['required', 'timezone'],
         ];
     }
 }

--- a/app/Repos/EventRepo.php
+++ b/app/Repos/EventRepo.php
@@ -253,9 +253,10 @@ class EventRepo
             }
             $event->days_of_week = request()->schedule_type == 'recurring' ? $days_of_week : null;
 
+            $event->timezone = $event->timezone ?: ($user->timezone ?? config('app.timezone', 'UTC'));
+
             if ($event->starts_at) {
-                $timezone = $user->timezone;
-                $event->starts_at = Carbon::createFromFormat('Y-m-d H:i:s', $event->starts_at, $timezone)
+                $event->starts_at = Carbon::createFromFormat('Y-m-d H:i:s', $event->starts_at, $event->timezone)
                     ->setTimezone('UTC')
                     ->format('Y-m-d H:i:s');
             }

--- a/app/Services/GoogleCalendarService.php
+++ b/app/Services/GoogleCalendarService.php
@@ -190,13 +190,13 @@ class GoogleCalendarService
 
             $startDateTime = new EventDateTime();
             $startDateTime->setDateTime($startAt->toRfc3339String());
-            $startDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
+            $startDateTime->setTimeZone($event->timezone ?? $event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setStart($startDateTime);
 
             $endDateTime = new EventDateTime();
             $endTime = $startAt->copy()->addHours($event->duration ?: 2);
             $endDateTime->setDateTime($endTime->toRfc3339String());
-            $endDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
+            $endDateTime->setTimeZone($event->timezone ?? $event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setEnd($endDateTime);
 
             // Set location
@@ -267,13 +267,13 @@ class GoogleCalendarService
 
             $startDateTime = new EventDateTime();
             $startDateTime->setDateTime($startAt->toRfc3339String());
-            $startDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
+            $startDateTime->setTimeZone($event->timezone ?? $event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setStart($startDateTime);
 
             $endDateTime = new EventDateTime();
             $endTime = $startAt->copy()->addHours($event->duration ?: 2);
             $endDateTime->setDateTime($endTime->toRfc3339String());
-            $endDateTime->setTimeZone($event->creatorRole->timezone ?? 'UTC');
+            $endDateTime->setTimeZone($event->timezone ?? $event->creatorRole->timezone ?? 'UTC');
             $googleEvent->setEnd($endDateTime);
 
             // Set location

--- a/app/Services/Wallet/AppleWalletService.php
+++ b/app/Services/Wallet/AppleWalletService.php
@@ -612,7 +612,8 @@ class AppleWalletService
 
     protected function resolveTimezone(Event $event): string
     {
-        return $event->venue?->timezone
+        return $event->timezone
+            ?? $event->venue?->timezone
             ?? $event->creatorRole?->timezone
             ?? config('app.timezone', 'UTC');
     }

--- a/app/Services/Wallet/GoogleWalletService.php
+++ b/app/Services/Wallet/GoogleWalletService.php
@@ -302,7 +302,8 @@ class GoogleWalletService
 
     protected function resolveTimezone(Event $event): string
     {
-        return $event->venue?->timezone
+        return $event->timezone
+            ?? $event->venue?->timezone
             ?? $event->creatorRole?->timezone
             ?? config('app.timezone', 'UTC');
     }

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -29,6 +29,7 @@ class EventFactory extends Factory
             'name' => $name,
             'slug' => Str::slug($name) . '-' . fake()->unique()->numberBetween(100, 999),
             'starts_at' => now()->addWeek(),
+            'timezone' => config('app.timezone', 'UTC'),
             'duration' => 2.5,
             'description' => fake()->sentence(),
             'description_html' => '<p>' . fake()->sentence() . '</p>',

--- a/database/migrations/2024_08_21_000000_add_timezone_to_events_table.php
+++ b/database/migrations/2024_08_21_000000_add_timezone_to_events_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->string('timezone')->default(config('app.timezone', 'UTC'))->after('starts_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('events', function (Blueprint $table) {
+            $table->dropColumn('timezone');
+        });
+    }
+};

--- a/resources/views/event/clone-confirm.blade.php
+++ b/resources/views/event/clone-confirm.blade.php
@@ -1,6 +1,6 @@
 <x-app-admin-layout>
     @php
-        $timezone = auth()->user()->timezone ?? config('app.timezone');
+    $timezone = $event->timezone ?? auth()->user()->timezone ?? config('app.timezone');
         $startDisplay = $startAt ? $startAt->copy()->locale(app()->getLocale())->translatedFormat('M j, Y • g:i A') : null;
         $endDisplay = $endAt ? $endAt->copy()->locale(app()->getLocale())->translatedFormat('M j, Y • g:i A') : null;
         $talentNames = $talents->map->translatedName()->implode(', ');

--- a/resources/views/event/edit.blade.php
+++ b/resources/views/event/edit.blade.php
@@ -697,6 +697,23 @@
                             <x-input-error class="mt-2" :messages="$errors->get('starts_at')" />
                         </div>
 
+                        @php
+                            $eventTimezone = old(
+                                'timezone',
+                                $event->timezone ?? ($role->timezone ?? $user->timezone ?? config('app.timezone'))
+                            );
+                        @endphp
+
+                        <div class="mb-6">
+                            <x-input-label for="timezone" :value="__('messages.timezone')" />
+                            <select id="timezone" name="timezone" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-[#4E81FA] focus:ring-[#4E81FA] dark:focus:border-[#4E81FA] dark:focus:ring-[#4E81FA]">
+                                @foreach(\Carbon\CarbonTimeZone::listIdentifiers() as $timezone)
+                                    <option value="{{ $timezone }}" @selected($eventTimezone === $timezone)>{{ $timezone }}</option>
+                                @endforeach
+                            </select>
+                            <x-input-error class="mt-2" :messages="$errors->get('timezone')" />
+                        </div>
+
                         <div class="mb-6">
                             <x-input-label for="duration" :value="__('messages.duration_in_hours')" />
                             <x-text-input type="number" id="duration" name="duration" step="0.01"

--- a/resources/views/event/view.blade.php
+++ b/resources/views/event/view.blade.php
@@ -1,6 +1,6 @@
 <x-app-admin-layout>
     @php
-        $timezone = auth()->user()->timezone ?? config('app.timezone');
+    $timezone = $event->timezone ?? auth()->user()->timezone ?? config('app.timezone');
         $startDisplay = $startAt ? $startAt->copy()->locale(app()->getLocale())->translatedFormat('M j, Y • g:i A') : null;
         $endDisplay = $endAt ? $endAt->copy()->locale(app()->getLocale())->translatedFormat('M j, Y • g:i A') : null;
         $talentNames = $talents->map->translatedName()->implode(', ');

--- a/tests/legacy/Feature/EventClaimMailTest.php
+++ b/tests/legacy/Feature/EventClaimMailTest.php
@@ -70,6 +70,7 @@ class EventClaimMailTest extends TestCase
             'venue_state' => 'TS',
             'venue_postal_code' => '12345',
             'venue_country_code' => 'US',
+            'timezone' => 'UTC',
         ];
 
         $response = $this->post(route('event.store', ['subdomain' => $organizerRole->subdomain]), $payload);


### PR DESCRIPTION
## Summary
- add a timezone column to events and include timezone in event API output
- ensure event start times are stored in UTC using the event timezone and pass timezone through related services
- expose timezone selection in the event form and validate timezone inputs

## Testing
- Not run (phpunit not available in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6939d8268c34832ea05fb201bacacaaf)