### PR TITLE
test(e2e): add E2E seed/teardown, Cypress specs, Pest tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      APP_ENV: testing
+      APP_DEBUG: 'true'
+      DB_CONNECTION: sqlite
+      DB_DATABASE: ':memory:'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, bcmath, xml, intl
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --no-interaction
+
+      - name: Create .env
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Prepare database
+        run: |
+          php artisan migrate --force
+          php artisan db:seed --force || true
+
+      - name: Run PHP tests
+        run: php artisan test --verbose
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v5
+        with:
+          start: php artisan serve --port 8000
+          wait-on: 'http://127.0.0.1:8000'
+          run: npm run cypress:run
+
+  e2e:
+    needs: tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        viewport: [
+          { name: 'desktop', width: 1280, height: 720 },
+          { name: 'mobile', width: 375, height: 812 }
+        ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run Cypress for ${{ matrix.viewport.name }}
+        uses: cypress-io/github-action@v5
+        with:
+          start: php artisan serve --port 8000
+          wait-on: 'http://127.0.0.1:8000'
+          run: npm run cypress:run -- --config viewportWidth=${{ matrix.viewport.width }},viewportHeight=${{ matrix.viewport.height }}

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Once configured, paid ticket emails and the ticket viewer will surface “Add to
 
 Event Schedule includes a comprehensive browser test suite powered by Laravel Dusk.
 
+Pest (optional):
+- To use Pest, install it locally (optional):
+  - `composer require --dev pestphp/pest`
+  - `php artisan pest:install`
+- Run Pest tests: `./vendor/bin/pest` or `php artisan test`
+
+
+
 > [!WARNING]  
 > WARNING: Running the tests will empty the database. 
 
@@ -183,7 +191,33 @@ cp .env .env.dusk.local
 
 ### Running Tests
 
+Run the automated tests locally or rely on CI to run them on PRs.
+
+PHP tests (Pest/PHPUnit):
 ```bash
-# Run all browser tests
+# Run PHP tests
+php artisan test
+```
+
+Cypress (E2E):
+```bash
+# install deps
+npm ci
+# open interactive
+npm run cypress:open
+# run headless
+npm run cypress:run
+```
+
+GitHub Actions CI: `.github/workflows/ci.yml` runs PHP tests and the Cypress smoke suite on push & PRs.
+
+Seed test data (local/testing only):
+
+```bash
+curl -X POST http://127.0.0.1:8000/__test/seed
+```
+
+```bash
+# Run all browser tests (if using Dusk)
 php artisan dusk
 ```

--- a/app/Http/Controllers/Test/TestHelpersController.php
+++ b/app/Http/Controllers/Test/TestHelpersController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers\Test;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Role;
+use App\Models\Event;
+use App\Models\Sale;
+use App\Models\SaleTicketEntry;
+
+class TestHelpersController extends Controller
+{
+    public function seedE2eData(Request $request)
+    {
+        if (! app()->environment(['local', 'testing'])) {
+            return response()->json(['error' => 'Not allowed'], 403);
+        }
+
+        $venue = Role::factory()->create(['type' => 'venue']);
+
+        // create a batch of events to support pagination tests
+        $events = [];
+        $createdEventObjects = [];
+        $baseDate = now()->startOfMonth()->addDays(1)->setTime(18, 0);
+        for ($i = 1; $i <= 15; $i++) {
+            $dt = $baseDate->copy()->addDays($i % 28);
+            $ev = Event::factory()->create([
+                'starts_at' => $dt,
+                'venue_id' => $venue->id,
+                'name' => "E2E Event {$i}",
+            ]);
+            $createdEventObjects[] = $ev;
+            $events[] = [
+                'id' => $ev->id,
+                'name' => $ev->translatedName(),
+                'starts_at' => $ev->starts_at ? $ev->getStartDateTime(null, true) : null,
+                'guest_url' => $ev->getGuestUrl(false, true),
+            ];
+        }
+
+        $recurring = Event::factory()->create([
+            'days_of_week' => '0100000', // Monday
+            'venue_id' => $venue->id,
+            'name' => 'E2E Recurring',
+        ]);
+
+        // create an admin user for admin flow tests
+        $adminPassword = 'password';
+        $admin = \App\Models\User::factory()->create([
+            'email' => 'e2e-admin@example.test',
+            'password' => bcrypt($adminPassword),
+        ]);
+
+        // assign ownership of first few events to admin so admin can manage them
+        if (! empty($createdEventObjects)) {
+            foreach (array_slice($createdEventObjects, 0, 3) as $ev) {
+                $ev->user_id = $admin->id;
+                $ev->save();
+            }
+        }
+
+        $sale = Sale::factory()->create(['secret' => 'sale-secret-ABC', 'event_id' => $createdEventObjects[0]->id]);
+        $entry = SaleTicketEntry::factory()->create(['secret' => 'entry-secret-123', 'sale_id' => $sale->id]);
+
+        // compute next few occurrences for the recurring event
+        $occurrences = [];
+        $start = now()->startOfMonth();
+        $end = now()->endOfMonth();
+        $d = $start->copy();
+        while ($d->lte($end) && count($occurrences) < 5) {
+            if ($recurring->matchesDate($d)) {
+                $occurrences[] = $d->format('Y-m-d');
+            }
+            $d->addDay();
+        }
+
+        $response = [
+            'venue_id' => $venue->id,
+            'events' => $events,
+            'recurring_id' => $recurring->id,
+            'recurring_name' => $recurring->translatedName(),
+            'recurring_occurrences' => $occurrences,
+            'sale_secret' => $sale->secret,
+            'entry_secret' => $entry->secret,
+            'created_event_ids' => array_map(fn($e) => $e['id'], $events),
+            'created_sale_ids' => [$sale->id],
+        ];
+
+        $response['admin_email'] = $admin->email;
+        $response['admin_password'] = $adminPassword;
+        $response['created_user_ids'] = [$admin->id];
+
+        return response()->json($response);
+    }
+
+    public function teardownE2eData(Request $request)
+    {
+        if (! app()->environment(['local', 'testing'])) {
+            return response()->json(['error' => 'Not allowed'], 403);
+        }
+
+        $eventIds = (array) $request->input('event_ids', []);
+        $saleIds = (array) $request->input('sale_ids', []);
+
+        if ($saleIds) {
+            \App\Models\SaleTicketEntry::whereIn('sale_id', $saleIds)->delete();
+            \App\Models\Sale::whereIn('id', $saleIds)->delete();
+        }
+
+        if ($eventIds) {
+            \App\Models\Event::whereIn('id', $eventIds)->delete();
+        }
+
+        $userIds = (array) $request->input('user_ids', []);
+        if ($userIds) {
+            \App\Models\User::whereIn('id', $userIds)->delete();
+        }
+
+        return response()->json(['deleted_event_ids' => $eventIds, 'deleted_sale_ids' => $saleIds]);
+    }
+}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,0 +1,11 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://127.0.0.1:8000',
+    setupNodeEvents(on, config) {
+      // implement node event listeners here
+    },
+    specPattern: 'cypress/e2e/**/*.spec.{js,ts}'
+  },
+})

--- a/cypress/e2e/landing.mobile.spec.js
+++ b/cypress/e2e/landing.mobile.spec.js
@@ -1,0 +1,38 @@
+describe('Landing mobile flows', () => {
+  beforeEach(() => {
+    cy.request({ method: 'POST', url: '/__test/seed', failOnStatusCode: false }).then((resp) => {
+      Cypress.env('seedData', resp.body || {});
+    });
+  });
+
+  it('shows mobile list and toggle', () => {
+    const seed = Cypress.env('seedData');
+    cy.viewport(375, 812);
+    cy.visit('/');
+    // mobile toggle should be visible
+    cy.get('.mb-4.flex.items-center.justify-end.md:hidden').should('exist');
+    // open mobile list by checking presence of mobile events list or by ensuring recurring event is visible
+    if (seed.recurring_name) {
+      cy.contains(seed.recurring_name).should('exist');
+
+      // assert the mobile list item has an image or time text for the event
+      cy.get('#mobileEventsList').within(() => {
+        cy.get('li').first().should('exist').and(($li) => {
+          expect($li.text()).to.include(seed.recurring_name);
+        });
+      });
+    }
+  });
+
+  it('recurring event appears on multiple dates', () => {
+    const seed = Cypress.env('seedData');
+    expect(seed.recurring_occurrences).to.be.an('array');
+    seed.recurring_occurrences.forEach((date) => {
+      // visit the month of the occurrence
+      const [y, m] = date.split('-');
+      cy.visit(`/?month=${parseInt(m)}&year=${y}`);
+      // assert the recurring name is visible somewhere on the page
+      cy.contains(seed.recurring_name).should('exist');
+    });
+  });
+});

--- a/cypress/e2e/landing.spec.js
+++ b/cypress/e2e/landing.spec.js
@@ -1,0 +1,87 @@
+describe('Landing page flows', () => {
+  before(() => {
+    // Seed test data via test helper endpoint (only available in local/testing env)
+    cy.request({
+      method: 'POST',
+      url: '/__test/seed',
+      failOnStatusCode: false,
+    }).then((resp) => {
+      // store secrets for later checks if needed
+      Cypress.env('seedData', resp.body || {});
+    });
+  });
+
+  after(() => {
+    const seed = Cypress.env('seedData') || {};
+    cy.request({
+      method: 'POST',
+      url: '/__test/teardown',
+      body: { event_ids: seed.created_event_ids || [], sale_ids: seed.created_sale_ids || [] },
+      failOnStatusCode: false,
+    });
+  });
+
+  it('renders calendar by default and event times/guest URLs are present', () => {
+    const seed = Cypress.env('seedData');
+    cy.visit('/');
+    cy.contains(/Upcoming Events|This month|calendar/i).should('exist');
+    cy.get('#calendar-app').should('exist');
+
+    // check that at least one seeded event name and guest URL are present on the page
+    cy.contains(seed.events[0].name).should('exist');
+    if (seed.events[0].guest_url) {
+      // anchor tag with guest url
+      cy.get(`a[href*="${seed.events[0].guest_url}"]`).should('exist');
+    }
+
+    // Tooltip test: hover over a calendar element with a tooltip and assert tooltip content
+    cy.get('.has-tooltip').first().trigger('mouseenter');
+    cy.get('#tooltip').should('be.visible').and('not.be.empty');
+
+    // check event time is visible in list view as well
+    const month = new Date(seed.events[0].starts_at).getMonth() + 1;
+    const year = new Date(seed.events[0].starts_at).getFullYear();
+    cy.visit(`/?view=list&month=${month}&year=${year}`);
+
+    // ensure the event time string appears in the first row
+    cy.get('table tbody tr').first().should(($tr) => {
+      expect($tr.text()).to.include(new Date(seed.events[0].starts_at).toLocaleString());
+    });
+  });
+
+  it('seed endpoint returned expected secrets', function () {
+    const seed = Cypress.env('seedData');
+    expect(seed).to.have.property('entry_secret');
+    expect(seed).to.have.property('sale_secret');
+  });
+
+  it('switches to list view and paginates', () => {
+    const seed = Cypress.env('seedData');
+    const month = new Date(seed.events[0].starts_at).getMonth() + 1;
+    const year = new Date(seed.events[0].starts_at).getFullYear();
+
+    cy.visit(`/?view=list&month=${month}&year=${year}`);
+
+    cy.get('table').should('exist');
+
+    // check rows count equals page size (10)
+    cy.get('table tbody tr').its('length').should('be.lte', 10);
+
+    // confirm pagination nav exists and click page 2
+    cy.get('nav').contains('2').click();
+
+    cy.url().should('include', 'page=2');
+
+    // ensure different content on page 2
+    cy.get('table tbody tr').first().should(($tr) => {
+      const text = $tr.text();
+      expect(text).to.not.include(seed.events[0].name);
+    });
+  });
+
+  it('month navigation preserves view param', () => {
+    cy.visit('/?view=list&month=12&year=2025');
+    cy.get('a').contains(/Next month|next/).click();
+    cy.url().should('include', 'view=list');
+  });
+});

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -1,0 +1,36 @@
+# E2E & Manual Testing Guide (Quickstart)
+
+This document summarizes how to run the manual and automated tests for EventSchedule.
+
+## Manual testing - prerequisites
+1. Ensure local server is running: `php artisan serve --host=127.0.0.1 --port=8000`.
+2. Ensure DB is seeded with test data (see `docs/e2e-test-plan-detailed.docx` for seeding tinker commands).
+
+## Running automated tests
+
+### CI
+A GitHub Actions workflow is included at `.github/workflows/ci.yml` which runs PHP tests and Cypress E2E tests on push and pull requests. The workflow uses an in-memory SQLite DB and starts a local server to run Cypress.
+
+
+### PHPUnit / Pest
+- Run all PHP tests:
+  - `php artisan test` (or `./vendor/bin/phpunit`)
+- Run single test:
+  - `php artisan test --filter ScanTicketApiTest`
+
+### Cypress
+- Install (if not installed): `npm install`.
+- Seed test data (local/testing only): `curl -X POST http://127.0.0.1:8000/__test/seed`
+- Open interactive runner: `npm run cypress:open`.
+- Run headless: `npm run cypress:run`.
+
+### Postman
+- Import `docs/postman/ScanAPI.postman_collection.json` into Postman and run the requests against your `baseUrl`.
+
+## Evidence collection
+- For UI tests: screenshots of the page, note the URL and timestamp.
+- For API tests: copy the JSON response and note HTTP status.
+- For server errors: capture `storage/logs/laravel.log` lines around the timestamp.
+
+## Reporting bugs
+Include reproduction steps, environment, exact commands/URLs, screenshots, and log excerpts.

--- a/docs/postman/ScanAPI.postman_collection.json
+++ b/docs/postman/ScanAPI.postman_collection.json
@@ -1,0 +1,38 @@
+{
+  "info": {
+    "name": "Scan API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "http://127.0.0.1:8000" }
+  ],
+  "item": [
+    {
+      "name": "Scan - Entry Secret",
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": { "mode": "raw", "raw": "{\"code\": \"entry-secret-123\", \"location\": \"door-1\"}" },
+        "url": { "raw": "{{baseUrl}}/api/tickets/scan", "host": ["{{baseUrl}}"], "path": ["api","tickets","scan"] }
+      }
+    },
+    {
+      "name": "Scan - Sale Secret",
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": { "mode": "raw", "raw": "{\"code\": \"sale-secret-ABC\", \"location\": \"door-1\"}" },
+        "url": { "raw": "{{baseUrl}}/api/tickets/scan", "host": ["{{baseUrl}}"], "path": ["api","tickets","scan"] }
+      }
+    },
+    {
+      "name": "Scan - Invalid Secret",
+      "request": {
+        "method": "POST",
+        "header": [{ "key": "Content-Type", "value": "application/json" }],
+        "body": { "mode": "raw", "raw": "{\"code\": \"invalid-secret\", \"location\": \"door-1\"}" },
+        "url": { "raw": "{{baseUrl}}/api/tickets/scan", "host": ["{{baseUrl}}"], "path": ["api","tickets","scan"] }
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build"
+        "build": "vite build",
+        "test": "php artisan test",
+        "cypress:open": "cypress open",
+        "cypress:run": "cypress run"
     },
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.2",

--- a/routes/web.php
+++ b/routes/web.php
@@ -363,3 +363,8 @@ if (config('app.env') == 'local') {
 
 Route::get('/home', [HomeController::class, 'landing'])->name('landing');
 Route::get('/{slug?}', [HomeController::class, 'root'])->name('home');
+
+if (app()->environment(['local', 'testing'])) {
+    Route::post('/__test/seed', [\App\Http\Controllers\Test\TestHelpersController::class, 'seedE2eData']);
+    Route::post('/__test/teardown', [\App\Http\Controllers\Test\TestHelpersController::class, 'teardownE2eData']);
+}

--- a/tests/Feature/ScanTicketApiTest.pest
+++ b/tests/Feature/ScanTicketApiTest.pest
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\Sale;
+use App\Models\SaleTicketEntry;
+use App\Models\Event;
+
+beforeEach(function () {
+    \Illuminate\Support\Facades\Log::spy();
+});
+
+it('scans entry secret successfully', function () {
+    $event = Event::factory()->create(['starts_at' => now()->addDays(1)]);
+    $sale = Sale::factory()->create(['secret' => 'sale-ABC', 'event_id' => $event->id]);
+    $entry = SaleTicketEntry::factory()->create(['secret' => 'entry-123', 'sale_id' => $sale->id]);
+
+    $response = $this->postJson('/api/tickets/scan', ['code' => 'entry-123', 'location' => 'door-1']);
+
+    $response->assertStatus(200);
+
+    \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($entry, $sale) {
+        return $message === 'scan_by_code: entry_found' && isset($context['entry_id']) && $context['entry_id'] === $entry->id && isset($context['sale_id']) && $context['sale_id'] === $sale->id;
+    });
+});
+
+it('falls back to sale secret when entry missing', function () {
+    $event = Event::factory()->create(['starts_at' => now()->addDays(1)]);
+    $sale = Sale::factory()->create(['secret' => 'sale-ABC', 'event_id' => $event->id]);
+
+    $response = $this->postJson('/api/tickets/scan', ['code' => 'sale-ABC', 'location' => 'door-1']);
+
+    $response->assertStatus(200);
+
+    \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($sale) {
+        return $message === 'scan_by_code: created_entry' && isset($context['sale_id']) && $context['sale_id'] === $sale->id;
+    });
+});
+
+it('rejects scan outside event time based on event timezone', function () {
+    $event = Event::factory()->create(['starts_at' => now()->subDays(10)]);
+    $sale = Sale::factory()->create(['secret' => 'old-sale', 'event_id' => $event->id]);
+
+    $response = $this->postJson('/api/tickets/scan', ['code' => 'old-sale', 'location' => 'door-1']);
+
+    $response->assertStatus(400);
+
+    \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($sale) {
+        return $message === 'scan_by_code: date_mismatch' && isset($context['sale_id']) && $context['sale_id'] === $sale->id;
+    });
+});
+
+it('logs not found for invalid code', function () {
+    $response = $this->postJson('/api/tickets/scan', ['code' => 'invalid-xyz', 'location' => 'door']);
+
+    $response->assertStatus(404);
+
+    \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
+        return $message === 'scan_by_code: not_found' && isset($context['code']) && $context['code'] === 'invalid-xyz';
+    });
+});

--- a/tests/Feature/ScanTicketApiTest.php
+++ b/tests/Feature/ScanTicketApiTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Sale;
+use App\Models\SaleTicketEntry;
+use App\Models\Event;
+
+class ScanTicketApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_scans_entry_secret_successfully()
+    {
+        \Illuminate\Support\Facades\Log::spy();
+
+        $event = Event::factory()->create(['starts_at' => now()->addDays(1)]);
+        $sale = Sale::factory()->create(['secret' => 'sale-ABC', 'event_id' => $event->id]);
+        $entry = SaleTicketEntry::factory()->create(['secret' => 'entry-123', 'sale_id' => $sale->id]);
+
+        $response = $this->postJson('/api/tickets/scan', ['code' => 'entry-123', 'location' => 'door-1']);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['data']);
+
+        \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($entry, $sale) {
+            return $message === 'scan_by_code: entry_found' && isset($context['entry_id']) && $context['entry_id'] === $entry->id && isset($context['sale_id']) && $context['sale_id'] === $sale->id;
+        });
+    }
+
+    public function test_falls_back_to_sale_secret_when_entry_missing()
+    {
+        \Illuminate\Support\Facades\Log::spy();
+
+        $event = Event::factory()->create(['starts_at' => now()->addDays(1)]);
+        $sale = Sale::factory()->create(['secret' => 'sale-ABC', 'event_id' => $event->id]);
+
+        $response = $this->postJson('/api/tickets/scan', ['code' => 'sale-ABC', 'location' => 'door-1']);
+
+        $response->assertStatus(200);
+        $response->assertJson(['data' => ['sale_id' => $sale->id]]);
+
+        \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($sale) {
+            return $message === 'scan_by_code: created_entry' && isset($context['sale_id']) && $context['sale_id'] === $sale->id;
+        });
+    }
+
+    public function test_rejects_scan_outside_event_time_based_on_event_timezone()
+    {
+        \Illuminate\Support\Facades\Log::spy();
+
+        // Create event in the past relative to now
+        $event = Event::factory()->create(['starts_at' => now()->subDays(10)]);
+        $sale = Sale::factory()->create(['secret' => 'old-sale', 'event_id' => $event->id]);
+
+        $response = $this->postJson('/api/tickets/scan', ['code' => 'old-sale', 'location' => 'door-1']);
+
+        $response->assertStatus(400);
+        $this->assertArrayHasKey('error', $response->json());
+
+        \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) use ($sale) {
+            return $message === 'scan_by_code: date_mismatch' && isset($context['sale_id']) && $context['sale_id'] === $sale->id;
+        });
+    }
+
+    public function test_logs_not_found_for_invalid_code()
+    {
+        \Illuminate\Support\Facades\Log::spy();
+
+        $response = $this->postJson('/api/tickets/scan', ['code' => 'invalid-xyz', 'location' => 'door']);
+
+        $response->assertStatus(404);
+
+        \Illuminate\Support\Facades\Log::shouldHaveReceived('info')->withArgs(function ($message, $context) {
+            return $message === 'scan_by_code: not_found' && isset($context['code']) && $context['code'] === 'invalid-xyz';
+        });
+    }
+}


### PR DESCRIPTION
This PR adds E2E test automation: seed & teardown endpoints, Cypress specs (desktop & mobile), Pest tests for scan API, and a GitHub Actions workflow to run PHPUnit and Cypress with a viewport matrix. The seeding endpoints are guarded to local/testing environments.\n\nCI workflow: .github/workflows/ci.yml