### PR TITLE
ci(dusk): make 'npm ci' resilient with fallback to 'npm install'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,8 @@ jobs:
 
       - name: Install npm dependencies and build assets
         run: |
-          npm ci
+          # Prefer a clean install from lockfile, fall back to npm install if lockfile mismatch occurs
+          npm ci --no-audit --no-fund || npm install --no-audit --no-fund
           npm run build
         env:
           LARAVEL_BYPASS_ENV_CHECK: 1


### PR DESCRIPTION
Add fallback to 
added 445 packages, and audited 446 packages in 19m

78 packages are looking for funding
  run `npm fund` for details

11 vulnerabilities (3 moderate, 6 high, 2 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details. for the Dusk job's npm install step so transient lockfile mismatches won't fail the job. This mirrors the resilient install used in the other CI jobs.