### PR TITLE
ci(debug): add 'specs' input & weekly schedule to Cypress debug workflow; docs

### DIFF
--- a/.github/workflows/cypress-debug.yml
+++ b/.github/workflows/cypress-debug.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches:
       - debug/cypress-failures
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      specs:
+        description: 'Comma-separated list of spec globs to run (example: "cypress/e2e/admin.spec.js,cypress/e2e/landing.spec.js")'
+        required: false
+        default: ''
+  schedule:
+    - cron: '0 0 * * 0' # weekly on Sunday UTC
 
 jobs:
   debug-cypress:
@@ -95,12 +102,23 @@ jobs:
         run: php artisan serve --port 8000 &
 
       - name: Run failing Cypress specs
+        env:
+          SPEC_INPUT: "${{ github.event.inputs.specs }}"
         run: |
           mkdir -p cypress/screenshots cypress/videos
-          # Run only the failing specs we observed; keep cmd idempotent and non-blocking
-          npx cypress run --spec "cypress/e2e/admin.spec.js" || true
-          npx cypress run --spec "cypress/e2e/landing.mobile.spec.js" || true
-          npx cypress run --spec "cypress/e2e/landing.spec.js" || true
+
+          # If `specs` input was provided, run those (comma-separated list); otherwise run the known failing specs
+          if [ -n "$SPEC_INPUT" ]; then
+            IFS=',' read -ra SPECS <<< "$SPEC_INPUT"
+            for s in "${SPECS[@]}"; do
+              echo "Running spec: $s"
+              npx cypress run --spec "$s" || true
+            done
+          else
+            npx cypress run --spec "cypress/e2e/admin.spec.js" || true
+            npx cypress run --spec "cypress/e2e/landing.mobile.spec.js" || true
+            npx cypress run --spec "cypress/e2e/landing.spec.js" || true
+          fi
 
       - name: Upload Cypress artifacts
         uses: actions/upload-artifact@v4

--- a/docs/CYPRESS_DEBUG.md
+++ b/docs/CYPRESS_DEBUG.md
@@ -1,0 +1,12 @@
+# Cypress debug workflow
+
+This document explains the `Cypress debug (failing specs)` workflow.
+
+- Triggering manually: go to Actions → "Cypress debug (failing specs)" → Run workflow. You can optionally provide `specs` as a comma-separated list of spec globs to run.
+  - Example `specs` value: `cypress/e2e/admin.spec.js,cypress/e2e/landing.spec.js`
+
+- Scheduled run: the workflow is scheduled to run weekly (Sunday UTC) to surface regressions early.
+
+- Behavior: when run it will start a local MySQL, migrate, seed, install deps (with a fallback to `npm install`), build assets and run the specified Cypress specs. Artifacts (screenshots, videos, results) are uploaded to the run for triage.
+
+- Tip: use the `specs` input to target specific failing specs and capture artifacts without running the full suite.


### PR DESCRIPTION
Adds a  workflow input (comma-separated list) so maintainers can run arbitrary spec globs via the Cypress debug workflow, and schedules a weekly run to catch regressions. Also adds docs/CYPRESS_DEBUG.md describing usage.

This keeps the default behavior unchanged when no input is supplied.